### PR TITLE
Remove resume from navbar

### DIFF
--- a/src/components/NavPill.tsx
+++ b/src/components/NavPill.tsx
@@ -14,11 +14,6 @@ const links = [
     link: "/#portfolio",
   },
   {
-    label: "Resume",
-    link: "/Gram_Liu_Resume.pdf",
-    target: "_blank",
-  },
-  {
     label: "Library",
     link: "/library",
   },


### PR DESCRIPTION
Remove the resume link from the navbar as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa5280f1-ad39-493b-a87e-1765a824ba0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa5280f1-ad39-493b-a87e-1765a824ba0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the "Resume" link from `src/components/NavPill.tsx` so it no longer appears in the navbar.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69fe99bc89c34a982c7a8a186bae6ac861ceb3c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->