### PR TITLE
Remove instagram reference

### DIFF
--- a/src/components/bio.mdx
+++ b/src/components/bio.mdx
@@ -11,4 +11,4 @@ is possible. I'm particularly interested in recent breakthroughs in AI and how
 they're set to change the way we build, create, and learn.
 <br />
 Outside of tech, I also love to cook! I try to do the food justice by honing the
-art of food photography over on [@gram_cooks](https://www.instagram.com/gram_cooks/).
+art of food photography whenever I can.

--- a/src/components/bio.mdx
+++ b/src/components/bio.mdx
@@ -9,6 +9,3 @@ I'm a big fan of technology and how it revolutionizes the way we tackle everythi
 from payments to education, consistently pushing the boundaries of what we think
 is possible. I'm particularly interested in recent breakthroughs in AI and how 
 they're set to change the way we build, create, and learn.
-<br />
-Outside of tech, I also love to cook! I try to do the food justice by honing the
-art of food photography whenever I can.


### PR DESCRIPTION
Remove the cooking Instagram reference (`@gram_cooks`) from the bio section.

---
<a href="https://cursor.com/background-agent?bcId=bc-410482f3-5cb5-46fe-885b-f27064a9338c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-410482f3-5cb5-46fe-885b-f27064a9338c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove the cooking/Instagram paragraph and trailing line break from `src/components/bio.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2911ec9fcc0e5d539b56490f4a20422ed41f8389. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->