### PR TITLE
Essays json reorder

### DIFF
--- a/src/config/blogs.tsx
+++ b/src/config/blogs.tsx
@@ -11,6 +11,11 @@ const blogs: Blog[] = [
     author: "Paul Graham"
   },
   {
+    title: "Staff Archetypes",
+    url: "https://staffeng.com/guides/staff-archetypes/",
+    author: "Will Larson"
+  },
+  {
     title: "Exit the haunted forest",
     url: "https://increment.com/software-architecture/exit-the-haunted-forest/",
     author: "John Millikin"
@@ -54,11 +59,6 @@ const blogs: Blog[] = [
     title: "You and Your Research",
     url: "https://d37ugbyn3rpeym.cloudfront.net/stripe-press/TAODSAE_zine_press.pdf",
     author: "Richard Hamming"
-  },
-  {
-    title: "Staff Archetypes",
-    url: "https://staffeng.com/guides/staff-archetypes/",
-    author: "Will Larson"
   },
   {
     title: "Michelle Bu - Payments Products Tech Lead at Stripe",


### PR DESCRIPTION
Move "Staff Archetypes" to the second entry in the `blogs` list in `src/config/blogs.tsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e8cd527-8733-4cdb-9cf3-0f6e299fed07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e8cd527-8733-4cdb-9cf3-0f6e299fed07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders the `blogs` list to surface `Staff Archetypes` near the top.
> 
> - Inserts `Staff Archetypes` as the second item and removes its previous entry later in `src/config/blogs.tsx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 370fd47990a1a1abc9b447733dff9192499acbd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->