### PR TITLE
Blogs section setup

### DIFF
--- a/blogs/example-blog-post.md
+++ b/blogs/example-blog-post.md
@@ -13,7 +13,7 @@ This is an example blog post written in Markdoc. It demonstrates the basic struc
 
 Welcome to this example blog post! This post is configured as **unpublished** in the frontmatter, which means it won't appear on the blogs page by default.
 
-To view unpublished posts, add the `?showDrafts=true` query parameter to the URL.
+To view unpublished posts, add the `?includeDrafts=true` query parameter to the URL.
 
 ## Features
 

--- a/blogs/example-blog-post.md
+++ b/blogs/example-blog-post.md
@@ -1,0 +1,44 @@
+---
+title: Example Blog Post
+description: This is an example blog post to demonstrate the markdoc blog setup.
+date: 2024-12-24
+published: false
+---
+
+# Example Blog Post
+
+This is an example blog post written in Markdoc. It demonstrates the basic structure and formatting available.
+
+## Introduction
+
+Welcome to this example blog post! This post is configured as **unpublished** in the frontmatter, which means it won't appear on the blogs page by default.
+
+To view unpublished posts, add the `?showDrafts=true` query parameter to the URL.
+
+## Features
+
+Here are some features you can use in your blog posts:
+
+- **Bold text** for emphasis
+- *Italic text* for subtle emphasis
+- `Inline code` for technical terms
+
+### Code Blocks
+
+You can include code blocks:
+
+```javascript
+function greet(name) {
+  console.log(`Hello, ${name}!`);
+}
+```
+
+### Lists
+
+1. First item
+2. Second item
+3. Third item
+
+## Conclusion
+
+That's it for this example post. Happy blogging!

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "website",
       "version": "1.0.0",
       "dependencies": {
+        "@markdoc/markdoc": "^0.5.4",
+        "@markdoc/next.js": "^0.5.0",
         "@mdx-js/loader": "^2.3.0",
         "@mdx-js/react": "^2.3.0",
         "@next/mdx": "^13.5.6",
@@ -16,6 +18,7 @@
         "@react-three/drei": "^9.107.0",
         "@react-three/fiber": "^8.16.8",
         "@t3-oss/env-nextjs": "^0.6.1",
+        "@tailwindcss/typography": "^0.5.19",
         "@upstash/redis": "^1.22.0",
         "axios": "^1.4.0",
         "cheerio": "^1.0.0-rc.12",
@@ -225,6 +228,45 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@lokesh.dhakar/quantize/-/quantize-1.3.0.tgz",
       "integrity": "sha512-4KBSyaMj65d8A+2vnzLxtHFu4OmBU4IKO0yLxZ171Itdf9jGV4w+WbG7VsKts2jUdRkFSzsZqpZOz6hTB3qGAw=="
+    },
+    "node_modules/@markdoc/markdoc": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.5.4.tgz",
+      "integrity": "sha512-36YFNlqFk//gVNGm5xZaTWVwbAVF2AOmVjf1tiUrS6tCoD/YSkVy2E3CkAfhc5MlKcjparL/QFHCopxL4zRyaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.7.0"
+      },
+      "optionalDependencies": {
+        "@types/linkify-it": "^3.0.1",
+        "@types/markdown-it": "12.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@markdoc/next.js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@markdoc/next.js/-/next.js-0.5.0.tgz",
+      "integrity": "sha512-gzWvRc2dlxArQn1mDS4SHed46vkAoKBbXkELihQRYv1eVSA0u9eoNEdJXNuBL4Ajn9j2dPpwZp6nAVjN4nzZlA==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@markdoc/markdoc": "*",
+        "next": "*",
+        "react": "*"
+      }
     },
     "node_modules/@mdx-js/loader": {
       "version": "2.3.0",
@@ -1149,6 +1191,31 @@
         "zod": "^3.0.0"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
@@ -1230,6 +1297,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "3.0.12",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
@@ -1237,6 +1322,13 @@
       "dependencies": {
         "@types/unist": "^2"
       }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/mdx": {
       "version": "2.0.9",
@@ -1769,7 +1861,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -4468,7 +4559,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8273,6 +8363,23 @@
       "resolved": "https://registry.npmjs.org/@lokesh.dhakar/quantize/-/quantize-1.3.0.tgz",
       "integrity": "sha512-4KBSyaMj65d8A+2vnzLxtHFu4OmBU4IKO0yLxZ171Itdf9jGV4w+WbG7VsKts2jUdRkFSzsZqpZOz6hTB3qGAw=="
     },
+    "@markdoc/markdoc": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.5.4.tgz",
+      "integrity": "sha512-36YFNlqFk//gVNGm5xZaTWVwbAVF2AOmVjf1tiUrS6tCoD/YSkVy2E3CkAfhc5MlKcjparL/QFHCopxL4zRyaQ==",
+      "requires": {
+        "@types/linkify-it": "^3.0.1",
+        "@types/markdown-it": "12.2.3"
+      }
+    },
+    "@markdoc/next.js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@markdoc/next.js/-/next.js-0.5.0.tgz",
+      "integrity": "sha512-gzWvRc2dlxArQn1mDS4SHed46vkAoKBbXkELihQRYv1eVSA0u9eoNEdJXNuBL4Ajn9j2dPpwZp6nAVjN4nzZlA==",
+      "requires": {
+        "js-yaml": "^4.1.0"
+      }
+    },
     "@mdx-js/loader": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-2.3.0.tgz",
@@ -8779,6 +8886,25 @@
         "@t3-oss/env-core": "0.6.1"
       }
     },
+    "@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "requires": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "6.0.10",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+          "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        }
+      }
+    },
     "@tweenjs/tween.js": {
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
@@ -8857,6 +8983,22 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/linkify-it": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
+      "optional": true
+    },
+    "@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "optional": true,
+      "requires": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
     "@types/mdast": {
       "version": "3.0.12",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
@@ -8864,6 +9006,12 @@
       "requires": {
         "@types/unist": "^2"
       }
+    },
+    "@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "optional": true
     },
     "@types/mdx": {
       "version": "2.0.9",
@@ -9289,8 +9437,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "aria-query": {
       "version": "4.2.2",
@@ -11125,7 +11272,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@markdoc/markdoc": "^0.5.4",
+    "@markdoc/next.js": "^0.5.0",
     "@mdx-js/loader": "^2.3.0",
     "@mdx-js/react": "^2.3.0",
     "@next/mdx": "^13.5.6",
@@ -17,6 +19,7 @@
     "@react-three/drei": "^9.107.0",
     "@react-three/fiber": "^8.16.8",
     "@t3-oss/env-nextjs": "^0.6.1",
+    "@tailwindcss/typography": "^0.5.19",
     "@upstash/redis": "^1.22.0",
     "axios": "^1.4.0",
     "cheerio": "^1.0.0-rc.12",

--- a/pages/blogs/[slug].tsx
+++ b/pages/blogs/[slug].tsx
@@ -87,7 +87,7 @@ export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async (
   query,
 }) => {
   const slug = params?.slug as string;
-  const showDrafts = query.showDrafts === "true";
+  const showDrafts = query.includeDrafts === "true";
 
   const blog = getBlogBySlug(slug, showDrafts);
 

--- a/pages/blogs/[slug].tsx
+++ b/pages/blogs/[slug].tsx
@@ -1,7 +1,7 @@
 import Markdoc from "@markdoc/markdoc";
 import { motion } from "framer-motion";
 import { ArrowLeft } from "lucide-react";
-import { GetServerSideProps } from "next";
+import { GetStaticPaths, GetStaticProps } from "next";
 import Link from "next/link";
 import React from "react";
 import { Helmet } from "react-helmet";
@@ -53,7 +53,7 @@ export default function BlogPostPage({
                 className="inline-flex items-center gap-2 text-text-faded hover:text-text-primary transition-colors mb-8 no-underline"
               >
                 <ArrowLeft className="h-4 w-4" />
-                Back to blogs
+                Back to blog
               </Link>
 
               <header className="mb-12">
@@ -82,14 +82,27 @@ export default function BlogPostPage({
   );
 }
 
-export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async ({
+export const getStaticPaths: GetStaticPaths = async () => {
+  // Generate paths for ALL blogs including drafts
+  const blogs = getAllBlogs(true);
+
+  const paths = blogs.map((blog) => ({
+    params: { slug: blog.slug },
+  }));
+
+  return {
+    paths,
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<BlogPostPageProps> = async ({
   params,
-  query,
 }) => {
   const slug = params?.slug as string;
-  const showDrafts = query.includeDrafts === "true";
 
-  const blog = getBlogBySlug(slug, showDrafts);
+  // Get blog including drafts - all pages are statically generated
+  const blog = getBlogBySlug(slug, true);
 
   if (!blog) {
     return {

--- a/pages/blogs/[slug].tsx
+++ b/pages/blogs/[slug].tsx
@@ -1,0 +1,106 @@
+import Markdoc from "@markdoc/markdoc";
+import { motion } from "framer-motion";
+import { ArrowLeft } from "lucide-react";
+import { GetServerSideProps } from "next";
+import Link from "next/link";
+import React from "react";
+import { Helmet } from "react-helmet";
+import Layout from "../../src/components/Layout";
+import NavPill from "../../src/components/NavPill";
+import {
+  BlogFrontmatter,
+  getAllBlogs,
+  getBlogBySlug,
+} from "../../src/lib/markdoc/blogs";
+
+interface BlogPostPageProps {
+  frontmatter: BlogFrontmatter;
+  content: string;
+}
+
+export default function BlogPostPage({
+  frontmatter,
+  content,
+}: BlogPostPageProps) {
+  const formattedDate = new Date(frontmatter.date).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  // Parse and render markdoc content
+  const ast = Markdoc.parse(content);
+  const transformedContent = Markdoc.transform(ast);
+  const renderedContent = Markdoc.renderers.react(transformedContent, React);
+
+  return (
+    <>
+      <Helmet>
+        <title>{frontmatter.title} | Gram Liu</title>
+        <meta name="description" content={frontmatter.description} />
+      </Helmet>
+      <Layout>
+        <NavPill />
+        <div className="min-h-screen pt-32 pb-16 px-4">
+          <div className="max-w-3xl mx-auto">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+            >
+              <Link
+                href="/blogs"
+                className="inline-flex items-center gap-2 text-text-faded hover:text-text-primary transition-colors mb-8 no-underline"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back to blogs
+              </Link>
+
+              <header className="mb-12">
+                <h1 className="text-3xl md:text-4xl font-bold mb-4">
+                  {frontmatter.title}
+                  {!frontmatter.published && (
+                    <span className="ml-3 text-sm bg-yellow-600/20 text-yellow-500 px-2 py-1 rounded align-middle">
+                      Draft
+                    </span>
+                  )}
+                </h1>
+                <p className="text-text-faded text-lg mb-4">
+                  {frontmatter.description}
+                </p>
+                <time className="text-sm text-text-faded">{formattedDate}</time>
+              </header>
+
+              <article className="prose prose-invert prose-lg max-w-none">
+                {renderedContent}
+              </article>
+            </motion.div>
+          </div>
+        </div>
+      </Layout>
+    </>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async ({
+  params,
+  query,
+}) => {
+  const slug = params?.slug as string;
+  const showDrafts = query.showDrafts === "true";
+
+  const blog = getBlogBySlug(slug, showDrafts);
+
+  if (!blog) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      frontmatter: blog.frontmatter,
+      content: blog.content,
+    },
+  };
+};

--- a/pages/blogs/index.tsx
+++ b/pages/blogs/index.tsx
@@ -77,7 +77,7 @@ export default function BlogsPage({ blogs, showingDrafts }: BlogsPageProps) {
             {showingDrafts && (
               <div className="mb-8 p-3 bg-yellow-600/10 border border-yellow-600/30 rounded-lg text-center">
                 <p className="text-yellow-500 text-sm">
-                  Showing drafts. <Link href="/blogs" className="underline">Hide drafts</Link>
+                  Including drafts. <Link href="/blogs" className="underline">Hide drafts</Link>
                 </p>
               </div>
             )}
@@ -106,7 +106,7 @@ export default function BlogsPage({ blogs, showingDrafts }: BlogsPageProps) {
 export const getServerSideProps: GetServerSideProps<BlogsPageProps> = async ({
   query,
 }) => {
-  const showDrafts = query.showDrafts === "true";
+  const showDrafts = query.includeDrafts === "true";
   const blogs = getAllBlogs(showDrafts);
 
   return {

--- a/pages/blogs/index.tsx
+++ b/pages/blogs/index.tsx
@@ -1,0 +1,118 @@
+import { motion } from "framer-motion";
+import { GetServerSideProps } from "next";
+import Link from "next/link";
+import Layout from "../../src/components/Layout";
+import NavPill from "../../src/components/NavPill";
+import { BlogPost, getAllBlogs } from "../../src/lib/markdoc/blogs";
+
+interface BlogsPageProps {
+  blogs: BlogPost[];
+  showingDrafts: boolean;
+}
+
+function BlogCard({ blog }: { blog: BlogPost }) {
+  const formattedDate = new Date(blog.frontmatter.date).toLocaleDateString(
+    "en-US",
+    {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    }
+  );
+
+  return (
+    <Link href={`/blogs/${blog.slug}`} className="no-underline group">
+      <div className="border border-gray-700 rounded-lg p-6 transition-all hover:border-gray-500 hover:bg-gray-900/30">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            <h2 className="text-xl md:text-2xl font-semibold text-text-primary group-hover:text-text-highlight transition-colors">
+              {blog.frontmatter.title}
+              {!blog.frontmatter.published && (
+                <span className="ml-2 text-xs bg-yellow-600/20 text-yellow-500 px-2 py-0.5 rounded">
+                  Draft
+                </span>
+              )}
+            </h2>
+            <p className="text-text-faded mt-2">{blog.frontmatter.description}</p>
+          </div>
+          <time className="text-sm text-text-faded whitespace-nowrap">
+            {formattedDate}
+          </time>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20">
+      <p className="text-2xl md:text-3xl text-text-faded font-medium">
+        Coming soon
+      </p>
+      <p className="text-text-faded mt-2">
+        Check back later for new blog posts.
+      </p>
+    </div>
+  );
+}
+
+export default function BlogsPage({ blogs, showingDrafts }: BlogsPageProps) {
+  return (
+    <Layout>
+      <NavPill />
+      <div className="min-h-screen pt-32 pb-16 px-4">
+        <div className="max-w-3xl mx-auto">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <h1 className="text-4xl md:text-5xl font-bold text-center mb-4">
+              Blog
+            </h1>
+            <p className="text-text-faded text-center mb-12">
+              Thoughts, ideas, and reflections
+            </p>
+            {showingDrafts && (
+              <div className="mb-8 p-3 bg-yellow-600/10 border border-yellow-600/30 rounded-lg text-center">
+                <p className="text-yellow-500 text-sm">
+                  Showing drafts. <Link href="/blogs" className="underline">Hide drafts</Link>
+                </p>
+              </div>
+            )}
+          </motion.div>
+
+          {blogs.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.1 }}
+              className="flex flex-col gap-4"
+            >
+              {blogs.map((blog) => (
+                <BlogCard key={blog.slug} blog={blog} />
+              ))}
+            </motion.div>
+          )}
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<BlogsPageProps> = async ({
+  query,
+}) => {
+  const showDrafts = query.showDrafts === "true";
+  const blogs = getAllBlogs(showDrafts);
+
+  return {
+    props: {
+      blogs,
+      showingDrafts: showDrafts,
+    },
+  };
+};

--- a/src/components/NavPill.tsx
+++ b/src/components/NavPill.tsx
@@ -20,6 +20,10 @@ const links: NavLink[] = [
     link: "/#portfolio",
   },
   {
+    label: "Blogs",
+    link: "/blogs",
+  },
+  {
     label: "Library",
     link: "/library",
   },

--- a/src/components/NavPill.tsx
+++ b/src/components/NavPill.tsx
@@ -20,7 +20,7 @@ const links: NavLink[] = [
     link: "/#portfolio",
   },
   {
-    label: "Blogs",
+    label: "Blog",
     link: "/blogs",
   },
   {

--- a/src/lib/markdoc/blogs.ts
+++ b/src/lib/markdoc/blogs.ts
@@ -1,0 +1,157 @@
+import Markdoc from "@markdoc/markdoc";
+import fs from "fs";
+import path from "path";
+
+export interface BlogFrontmatter {
+  title: string;
+  description: string;
+  date: string;
+  published: boolean;
+  slug: string;
+}
+
+export interface BlogPost {
+  frontmatter: BlogFrontmatter;
+  content: string;
+  slug: string;
+}
+
+const BLOGS_DIR = path.join(process.cwd(), "blogs");
+
+/**
+ * Parse frontmatter from markdoc content
+ */
+function parseFrontmatter(content: string): {
+  frontmatter: Record<string, unknown>;
+  content: string;
+} {
+  const frontmatterRegex = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
+  const match = content.match(frontmatterRegex);
+
+  if (!match) {
+    return { frontmatter: {}, content };
+  }
+
+  const frontmatterStr = match[1];
+  const markdownContent = match[2];
+
+  const frontmatter: Record<string, unknown> = {};
+  const lines = frontmatterStr.split("\n");
+
+  for (const line of lines) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+
+    const key = line.slice(0, colonIndex).trim();
+    let value: string | boolean = line.slice(colonIndex + 1).trim();
+
+    // Handle boolean values
+    if (value === "true") value = true;
+    else if (value === "false") value = false;
+    // Remove quotes if present
+    else if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    frontmatter[key] = value;
+  }
+
+  return { frontmatter, content: markdownContent };
+}
+
+/**
+ * Get all blog posts
+ * @param includeUnpublished - Whether to include unpublished posts
+ */
+export function getAllBlogs(includeUnpublished = false): BlogPost[] {
+  if (!fs.existsSync(BLOGS_DIR)) {
+    return [];
+  }
+
+  const files = fs.readdirSync(BLOGS_DIR);
+  const markdocFiles = files.filter((file) => file.endsWith(".md"));
+
+  const blogs: BlogPost[] = [];
+
+  for (const file of markdocFiles) {
+    const filePath = path.join(BLOGS_DIR, file);
+    const fileContent = fs.readFileSync(filePath, "utf-8");
+    const { frontmatter, content } = parseFrontmatter(fileContent);
+
+    const slug = file.replace(/\.md$/, "");
+
+    const blogPost: BlogPost = {
+      frontmatter: {
+        title: (frontmatter.title as string) || "Untitled",
+        description: (frontmatter.description as string) || "",
+        date: (frontmatter.date as string) || "",
+        published: frontmatter.published === true,
+        slug,
+      },
+      content,
+      slug,
+    };
+
+    // Filter out unpublished posts unless explicitly requested
+    if (includeUnpublished || blogPost.frontmatter.published) {
+      blogs.push(blogPost);
+    }
+  }
+
+  // Sort by date, newest first
+  blogs.sort((a, b) => {
+    const dateA = new Date(a.frontmatter.date);
+    const dateB = new Date(b.frontmatter.date);
+    return dateB.getTime() - dateA.getTime();
+  });
+
+  return blogs;
+}
+
+/**
+ * Get a single blog post by slug
+ */
+export function getBlogBySlug(
+  slug: string,
+  includeUnpublished = false
+): BlogPost | null {
+  const filePath = path.join(BLOGS_DIR, `${slug}.md`);
+
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  const fileContent = fs.readFileSync(filePath, "utf-8");
+  const { frontmatter, content } = parseFrontmatter(fileContent);
+
+  const blogPost: BlogPost = {
+    frontmatter: {
+      title: (frontmatter.title as string) || "Untitled",
+      description: (frontmatter.description as string) || "",
+      date: (frontmatter.date as string) || "",
+      published: frontmatter.published === true,
+      slug,
+    },
+    content,
+    slug,
+  };
+
+  // Don't return unpublished posts unless explicitly requested
+  if (!includeUnpublished && !blogPost.frontmatter.published) {
+    return null;
+  }
+
+  return blogPost;
+}
+
+/**
+ * Parse and render markdoc content to React
+ */
+export function parseMarkdocContent(content: string) {
+  const ast = Markdoc.parse(content);
+  const transformedContent = Markdoc.transform(ast);
+  return transformedContent;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -93,7 +93,7 @@ module.exports = {
       serif: ['var(--font-roboto-slab)', "serif"],
     },
   },
-  plugins: [require("tailwindcss-animate"), addVariablesForColors],
+  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography"), addVariablesForColors],
 };
 
 // This plugin adds each Tailwind color as a global CSS variable, e.g. var(--gray-200).

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,6 +121,21 @@
   resolved "https://registry.npmjs.org/@lokesh.dhakar/quantize/-/quantize-1.3.0.tgz"
   integrity sha512-4KBSyaMj65d8A+2vnzLxtHFu4OmBU4IKO0yLxZ171Itdf9jGV4w+WbG7VsKts2jUdRkFSzsZqpZOz6hTB3qGAw==
 
+"@markdoc/markdoc@*", "@markdoc/markdoc@^0.5.4":
+  version "0.5.4"
+  resolved "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.5.4.tgz"
+  integrity sha512-36YFNlqFk//gVNGm5xZaTWVwbAVF2AOmVjf1tiUrS6tCoD/YSkVy2E3CkAfhc5MlKcjparL/QFHCopxL4zRyaQ==
+  optionalDependencies:
+    "@types/linkify-it" "^3.0.1"
+    "@types/markdown-it" "12.2.3"
+
+"@markdoc/next.js@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/@markdoc/next.js/-/next.js-0.5.0.tgz"
+  integrity sha512-gzWvRc2dlxArQn1mDS4SHed46vkAoKBbXkELihQRYv1eVSA0u9eoNEdJXNuBL4Ajn9j2dPpwZp6nAVjN4nzZlA==
+  dependencies:
+    js-yaml "^4.1.0"
+
 "@mdx-js/loader@^2.3.0", "@mdx-js/loader@>=0.15.0":
   version "2.3.0"
   resolved "https://registry.npmjs.org/@mdx-js/loader/-/loader-2.3.0.tgz"
@@ -498,6 +513,13 @@
   dependencies:
     "@t3-oss/env-core" "0.6.1"
 
+"@tailwindcss/typography@^0.5.19":
+  version "0.5.19"
+  resolved "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz"
+  integrity sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==
+  dependencies:
+    postcss-selector-parser "6.0.10"
+
 "@tweenjs/tween.js@~23.1.3":
   version "23.1.3"
   resolved "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz"
@@ -567,12 +589,30 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/linkify-it@*", "@types/linkify-it@^3.0.1":
+  version "3.0.5"
+  resolved "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz"
+  integrity sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==
+
+"@types/markdown-it@12.2.3":
+  version "12.2.3"
+  resolved "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz"
+  integrity sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==
+  dependencies:
+    "@types/linkify-it" "*"
+    "@types/mdurl" "*"
+
 "@types/mdast@^3.0.0":
   version "3.0.12"
   resolved "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz"
   integrity sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==
   dependencies:
     "@types/unist" "^2"
+
+"@types/mdurl@*":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz"
+  integrity sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==
 
 "@types/mdx@^2.0.0", "@types/mdx@^2.0.9":
   version "2.0.9"
@@ -3251,7 +3291,7 @@ neo-async@^2.6.2:
   resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-next@^14.0.4:
+next@*, next@^14.0.4:
   version "14.0.4"
   resolved "https://registry.npmjs.org/next/-/next-14.0.4.tgz"
   integrity sha512-qbwypnM7327SadwFtxXnQdGiKpkuhaRLE2uq62/nRul9cj9KhQ5LhHmlziTNqUidZotw/Q1I9OjirBROdUJNgA==
@@ -3563,6 +3603,14 @@ postcss-selector-parser@^6.0.11:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
+postcss-selector-parser@6.0.10:
+  version "6.0.10"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
 postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
@@ -3720,7 +3768,7 @@ react-use-measure@^2.1.7:
   resolved "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz"
   integrity sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==
 
-"react@^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0", "react@^15.5.4 || ^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.3.0 || ^17.0.0 || ^18.0.0", "react@^16.5.1 || ^17.0.0 || ^18.0.0", "react@^16.8 || ^17.0 || ^18.0", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", react@^18, react@^18.0.0, react@^18.2.0, "react@>= 16.8.0", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", react@>=16, react@>=16.13, react@>=16.3.0, react@>=16.8, react@>=17.0, "react@>=18 <19", react@>=18.0, react@>=18.0.0, react@>16.0.0, react@18.2.0:
+react@*, "react@^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0", "react@^15.5.4 || ^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.3.0 || ^17.0.0 || ^18.0.0", "react@^16.5.1 || ^17.0.0 || ^18.0.0", "react@^16.8 || ^17.0 || ^18.0", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", react@^18, react@^18.0.0, react@^18.2.0, "react@>= 16.8.0", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", react@>=16, react@>=16.13, react@>=16.3.0, react@>=16.8, react@>=17.0, "react@>=18 <19", react@>=18.0, react@>=18.0.0, react@>16.0.0, react@18.2.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
@@ -4138,7 +4186,7 @@ tailwindcss-animate@^1.0.6:
   resolved "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.6.tgz"
   integrity sha512-4WigSGMvbl3gCCact62ZvOngA+PRqhAn7si3TQ3/ZuPuQZcIEtVap+ENSXbzWhpojKB8CpvnIsrwBu8/RnHtuw==
 
-tailwindcss@^3.3.2, "tailwindcss@>=3.0.0 || insiders":
+tailwindcss@^3.3.2, "tailwindcss@>=3.0.0 || insiders", "tailwindcss@>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1":
   version "3.3.2"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz"
   integrity sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==


### PR DESCRIPTION
Add a new Markdoc-powered blogs section with draft post functionality and navigation integration.

This PR introduces a `/blogs` route, allowing content creators to write blog posts using Markdoc. Posts can be marked as `published: false` in their frontmatter, making them drafts that are excluded from the main blog list by default but viewable via a `?showDrafts=true` query parameter. This provides a flexible content management system for blog posts.

---
<a href="https://cursor.com/background-agent?bcId=bc-37d045a7-76b0-425c-a06f-c2126a051950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-37d045a7-76b0-425c-a06f-c2126a051950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

