### PR TITLE
Rename essays to blogs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Adding New Reads
 
-When adding a new read (essay/article) to the website:
+When adding a new read (blog/article) to the website:
 
-1. **Location**: Add a new entry to the essays data file located at `src/config/blogs.tsx`
+1. **Location**: Add a new entry to the blogs data file located at `src/config/blogs.tsx`
 
 2. **Entry Format**: Each entry should follow this structure:
    ```typescript

--- a/src/components/Blogs.tsx
+++ b/src/components/Blogs.tsx
@@ -54,7 +54,7 @@ const BlogList = memo(function BlogList({ blogs }: { blogs: Blog[] }) {
 });
 
 export default function Blogs({ className }: { className?: string }) {
-  // Group essays into pages
+  // Group blogs into pages
   const pages = useMemo(() => paginate(blogs, PAGE_SIZE), []);
   const [page, setPage] = useState(0);
   const currentBlogs = pages[page] ?? [];
@@ -62,10 +62,10 @@ export default function Blogs({ className }: { className?: string }) {
   return (
     <div className={className}>
       <div
-        id="essays"
+        id="blogs"
         className="flex items-center justify-center text-center w-full font-bold text-3xl mb-8 mx-auto"
       >
-        Essays
+        Blogs
       </div>
       <div className="flex flex-col items-center justify-center p-4">
         <PaginationControls


### PR DESCRIPTION
Rename the "Essays" section to "Blogs" to align with updated terminology.

---
<a href="https://cursor.com/background-agent?bcId=bc-28e83e0c-4b2d-4363-a4bb-661d61b3d8fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-28e83e0c-4b2d-4363-a4bb-661d61b3d8fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

