### PR TITLE
Bookshelf multi-level wrap

### DIFF
--- a/src/components/Bookshelf.tsx
+++ b/src/components/Bookshelf.tsx
@@ -26,10 +26,10 @@ function InteractiveBookshelf({ books }: { books: Book[] }) {
             }
           }}
           className={clsx(
-            "flex shrink-0 flex-row items-center outline-none",
+            "relative flex shrink-0 flex-row items-center outline-none w-[50px]",
             focusedIndex !== index &&
               "hover:-translate-y-4 focus-visible:-translate-y-4",
-            focusedIndex === index ? "basis-72" : "basis-12",
+            focusedIndex === index && "z-10",
             animationStyle
           )}
           style={{ perspective: "1000px", WebkitPerspective: "1000px" }}
@@ -61,7 +61,7 @@ function InteractiveBookshelf({ books }: { books: Book[] }) {
           </div>
           <div
             className={clsx(
-              "relative z-10 h-72 shrink-0 origin-left overflow-hidden border-gray-900 brightness-[0.80] contrast-[2.00]",
+              "absolute left-[50px] z-10 h-72 shrink-0 origin-left overflow-hidden border-gray-900 brightness-[0.80] contrast-[2.00]",
               animationStyle
             )}
             style={{

--- a/src/components/Bookshelf.tsx
+++ b/src/components/Bookshelf.tsx
@@ -12,7 +12,7 @@ function InteractiveBookshelf({ books }: { books: Book[] }) {
   return (
     <div
       role="list"
-      className="md:flex flex-row flex-start gap-4 lg:w-8/12 mx-auto hidden pb-4 overflow-x-auto"
+      className="md:flex flex-row flex-wrap justify-center gap-x-4 gap-y-8 lg:w-10/12 mx-auto hidden pb-4"
     >
       {books.map((book, index) => (
         <button


### PR DESCRIPTION
Update the interactive bookshelf to wrap books into multiple rows on desktop.

This change improves the layout and prevents horizontal scrolling when there are more books than can fit horizontally on the screen by replacing `overflow-x-auto` with `flex-wrap`, adding vertical gap, and centering items.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6567552-0ebb-409f-8de8-fa1eeac94220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c6567552-0ebb-409f-8de8-fa1eeac94220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

