### PR TITLE
PostgreSQL scaling

### DIFF
--- a/src/config/blogs.tsx
+++ b/src/config/blogs.tsx
@@ -140,6 +140,11 @@ const blogs: Blog[] = [
     url: "https://copyconstruct.medium.com/distributed-tracing-weve-been-doing-it-wrong-39fc92a857df",
     author: "Cindy Sridharan"
   },
+  {
+    title: "Scaling PostgreSQL to power 800 million ChatGPT users",
+    url: "https://openai.com/index/scaling-postgresql/",
+    author: "OpenAI"
+  },
 ];
 
 export default blogs;


### PR DESCRIPTION
Add OpenAI's "Scaling PostgreSQL" blog post to the list of recommended blogs.

---
<a href="https://cursor.com/background-agent?bcId=bc-be2c71df-05b6-4696-9038-1e68f416e47b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-be2c71df-05b6-4696-9038-1e68f416e47b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Add blog entry to recommendations**
> 
> - Appends a new `Blog` entry (title, url, author) to `src/config/blogs.tsx` for OpenAI’s "Scaling PostgreSQL to power 800 million ChatGPT users".
> 
> *No logic changes; content-only update.*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db367344e7df7b7de9607d434da326326ebd492e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->