### PR TITLE
Book spines text overflow

### DIFF
--- a/src/components/Bookshelf.tsx
+++ b/src/components/Bookshelf.tsx
@@ -53,7 +53,7 @@ function InteractiveBookshelf({ books }: { books: Book[] }) {
               className="pointer-events-none fixed top-0 left-0 z-50 h-full w-full opacity-40 [filter:url(#paper)]"
             />
             <h2
-              className="text-base m-auto text-ellipsis h-64 w-[44px] font-serif line-clamp-2 align-middle leading-tight text-start"
+              className="m-auto h-64 w-[2.5em] overflow-hidden break-words font-serif text-base leading-tight text-start"
               style={{ writingMode: "vertical-rl" }}
             >
               {book.title}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix book spine text overflow on the `/library` page.

The previous combination of `text-ellipsis` and `line-clamp-2` with vertical text caused small white dot artifacts on truncation. This PR replaces it with `overflow-hidden` and a fixed width to cleanly limit the vertical title to two lines without rendering ellipsis dots.

---
<p><a href="https://cursor.com/agents/bc-9202f2ec-d902-4183-aa62-efcd564fc3a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9202f2ec-d902-4183-aa62-efcd564fc3a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->