### PR TITLE
Update Decagon bio copy

### DIFF
--- a/src/components/bio.mdx
+++ b/src/components/bio.mdx
@@ -2,7 +2,7 @@ Hi! I'm Gram and I love building things, from web to mobile to IoT.
 I grew up in Cebu, Philippines where I attended the [Philippine Science High School](https://en.wikipedia.org/wiki/Philippine_Science_High_School_System).
 I graduated from [Carnegie Mellon University](https://www.cmu.edu/) with a major in Electrical and Computer Engineering and a minor in Computer Science.
 I was previously at Stripe where I worked on [Tap to Pay](https://stripe.com/terminal/tap-to-pay).
-Today, I'm at [Decagon](https://decagon.ai/) in San Francisco 🌉 building enterprise-grade AI agents for customer support.
+Today, I'm at [Decagon](https://decagon.ai/) shaping the future of how enterprises build AI agents, paving the way for building truly personalized concierge experiences for every consumer.
 
 <br />
 I'm a big fan of technology and how it revolutionizes the way we tackle everything

--- a/src/config/activities.tsx
+++ b/src/config/activities.tsx
@@ -12,6 +12,13 @@ export interface Activity {
 
 const activities: Activity[] = [
   {
+    title: "Decagon",
+    url: "https://decagon.ai/",
+    dates: "Oct 2024 - Present",
+    role: "Member of Technical Staff",
+    description: ["Building"],
+  },
+  {
     title: "Stripe",
     url: "https://stripe.com/",
     dates: "July 2023 - Oct 2024",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Updates the About Me Decagon sentence to focus on enterprise AI agents and personalized concierge experiences.
- Adds Decagon as the first What I've Done entry with the Member of Technical Staff role and a concise Building bullet.

### Walkthrough
[decagon_bio_homepage_walkthrough.mp4](https://cursor.com/agents/bc-8479fffe-1e52-4791-ac43-cedf57f519b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdecagon_bio_homepage_walkthrough.mp4)
[About Me Decagon sentence](https://cursor.com/agents/bc-8479fffe-1e52-4791-ac43-cedf57f519b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fabout_me_decagon_sentence.webp)
[What I](https://cursor.com/agents/bc-8479fffe-1e52-4791-ac43-cedf57f519b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwhat_ive_done_decagon_entry.webp)

### Testing
- `bun run lint` passed.
- `bun run build` passed; Goodreads returned a sign-in page during library generation and the app used the configured `public/books.json` fallback.
- Manual homepage walkthrough passed, verifying the updated About Me sentence and default Decagon activity entry.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8479fffe-1e52-4791-ac43-cedf57f519b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8479fffe-1e52-4791-ac43-cedf57f519b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

