### PR TITLE
Add 3D keyboard preview

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -108,9 +108,6 @@ export default function Hero() {
             <World size={0.8} interactiveMode={isPlaying} closeUp />
           </div>
           <div className="hidden md:flex flex-col justify-start items-center text-center gap-5 pt-10">
-            <div className="w-full max-w-[520px] px-4">
-              <KeyboardPreview />
-            </div>
             <button
               onClick={() => setIsPlaying(!isPlaying)}
               className={clsx(
@@ -123,12 +120,9 @@ export default function Hero() {
               {isPlaying ? "Stop playing" : "Start playing"}
             </button>
             {isPlaying ? (
-              <>
-                {/* Instructions */}
-                <span className="text-center">
-                  Use WASD + Space to move around.
-                </span>
-              </>
+              <div className="w-full max-w-[520px] px-4">
+                <KeyboardPreview />
+              </div>
             ) : null}
           </div>
         </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -107,7 +107,7 @@ export default function Hero() {
           <div>
             <World size={0.8} interactiveMode={isPlaying} closeUp />
           </div>
-          <div className="hidden md:flex flex-col justify-start items-center text-center gap-5 pt-10">
+          <div className="hidden md:flex flex-col justify-start items-center text-center gap-8 pt-10">
             <button
               onClick={() => setIsPlaying(!isPlaying)}
               className={clsx(
@@ -120,7 +120,7 @@ export default function Hero() {
               {isPlaying ? "Stop playing" : "Start playing"}
             </button>
             {isPlaying ? (
-              <div className="w-full max-w-[520px] px-4">
+              <div className="w-full max-w-[520px] px-4 pt-2">
                 <KeyboardPreview />
               </div>
             ) : null}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { useEffect, useState } from "react";
 import ProfilePhoto from "../../public/images/profilePhoto.jpg";
 import social from "../config/social";
+import KeyboardPreview from "./keyboard";
 import World from "./world";
 
 function HeroContent() {
@@ -106,7 +107,10 @@ export default function Hero() {
           <div>
             <World size={0.8} interactiveMode={isPlaying} closeUp />
           </div>
-          <div className="hidden md:flex flex-col justify-start items-center text-center gap-5 pt-32">
+          <div className="hidden md:flex flex-col justify-start items-center text-center gap-5 pt-10">
+            <div className="w-full max-w-[520px] px-4">
+              <KeyboardPreview />
+            </div>
             <button
               onClick={() => setIsPlaying(!isPlaying)}
               className={clsx(

--- a/src/components/keyboard/index.tsx
+++ b/src/components/keyboard/index.tsx
@@ -115,7 +115,7 @@ function KeyboardScene({ pressedKeys }: { pressedKeys: Set<KeyCode> }) {
       <ambientLight intensity={0.7} />
       <directionalLight position={[0, 5, 4]} intensity={1.45} castShadow />
       <Center>
-        <group rotation={[Math.PI / 4, 0, 0]}>
+        <group rotation={[Math.PI / 6, 0, 0]}>
           <RoundedBox
             args={[4.6, 0.22, 3.9]}
             radius={0.12}

--- a/src/components/keyboard/index.tsx
+++ b/src/components/keyboard/index.tsx
@@ -1,0 +1,172 @@
+import { Center, ContactShadows, OrbitControls, RoundedBox } from "@react-three/drei";
+import { Canvas } from "@react-three/fiber";
+import { useEffect, useState } from "react";
+import { Keycap } from "./keycap";
+
+type KeyCode = "KeyW" | "KeyA" | "KeyS" | "KeyD" | "Space";
+
+interface KeyboardKey {
+  code: KeyCode;
+  label: string;
+  position: [number, number, number];
+  width?: number;
+  depth?: number;
+}
+
+const KEY_LAYOUT: KeyboardKey[] = [
+  { code: "KeyW", label: "W", position: [0, 0, -1] },
+  { code: "KeyA", label: "A", position: [-1.05, 0, 0] },
+  { code: "KeyS", label: "S", position: [0, 0, 0] },
+  { code: "KeyD", label: "D", position: [1.05, 0, 0] },
+  {
+    code: "Space",
+    label: "Space",
+    position: [0, 0, 1.05],
+    width: 3.2,
+    depth: 0.8,
+  },
+];
+
+const TRACKED_CODES = new Set<KeyCode>(KEY_LAYOUT.map((key) => key.code));
+
+function isTrackedKey(code: string): code is KeyCode {
+  return TRACKED_CODES.has(code as KeyCode);
+}
+
+function isEditableTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return (
+    target.isContentEditable ||
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA" ||
+    target.tagName === "SELECT"
+  );
+}
+
+function usePressedKeys() {
+  const [pressedKeys, setPressedKeys] = useState<Set<KeyCode>>(new Set());
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isTrackedKey(event.code) || isEditableTarget(event.target)) {
+        return;
+      }
+
+      event.preventDefault();
+      setPressedKeys((current) => {
+        if (current.has(event.code)) {
+          return current;
+        }
+
+        const next = new Set(current);
+        next.add(event.code);
+        return next;
+      });
+    };
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (!isTrackedKey(event.code) || isEditableTarget(event.target)) {
+        return;
+      }
+
+      event.preventDefault();
+      setPressedKeys((current) => {
+        if (!current.has(event.code)) {
+          return current;
+        }
+
+        const next = new Set(current);
+        next.delete(event.code);
+        return next;
+      });
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, []);
+
+  return pressedKeys;
+}
+
+function KeyboardScene({ pressedKeys }: { pressedKeys: Set<KeyCode> }) {
+  return (
+    <>
+      <ambientLight intensity={0.7} />
+      <directionalLight position={[3, 5, 4]} intensity={1.4} castShadow />
+      <Center>
+        <group rotation={[0, -0.22, 0]}>
+          <RoundedBox
+            args={[4.6, 0.22, 3.2]}
+            radius={0.12}
+            smoothness={4}
+            position={[0, 0.05, 0.08]}
+            receiveShadow
+          >
+            <meshStandardMaterial
+              color="#263140"
+              roughness={0.58}
+              metalness={0.18}
+            />
+          </RoundedBox>
+          <RoundedBox
+            args={[4.9, 0.18, 3.5]}
+            radius={0.14}
+            smoothness={4}
+            position={[0, -0.1, 0.08]}
+            receiveShadow
+          >
+            <meshStandardMaterial
+              color="#9fa4a8"
+              roughness={0.42}
+              metalness={0.35}
+            />
+          </RoundedBox>
+          {KEY_LAYOUT.map((key) => (
+            <Keycap
+              key={key.code}
+              label={key.label}
+              position={key.position}
+              width={key.width}
+              depth={key.depth}
+              pressed={pressedKeys.has(key.code)}
+            />
+          ))}
+        </group>
+      </Center>
+      <ContactShadows
+        position={[0, -0.28, 0]}
+        opacity={0.35}
+        scale={6}
+        blur={2}
+        far={3}
+      />
+      <OrbitControls enableZoom={false} enablePan={false} enabled={false} />
+    </>
+  );
+}
+
+export default function KeyboardPreview() {
+  const pressedKeys = usePressedKeys();
+
+  return (
+    <div className="h-[240px] w-full overflow-hidden rounded-2xl border border-highlight/20 bg-bgcolor-highlight/20">
+      <Canvas
+        camera={{
+          position: [3.9, 3.2, 4.5],
+          fov: 42,
+        }}
+        shadows
+      >
+        <KeyboardScene pressedKeys={pressedKeys} />
+      </Canvas>
+    </div>
+  );
+}

--- a/src/components/keyboard/index.tsx
+++ b/src/components/keyboard/index.tsx
@@ -115,7 +115,7 @@ function KeyboardScene({ pressedKeys }: { pressedKeys: Set<KeyCode> }) {
       <ambientLight intensity={0.7} />
       <directionalLight position={[0, 5, 4]} intensity={1.45} castShadow />
       <Center>
-        <group rotation={[0.16, 0, 0]}>
+        <group rotation={[Math.PI / 4, 0, 0]}>
           <RoundedBox
             args={[4.6, 0.22, 3.2]}
             radius={0.12}
@@ -171,7 +171,7 @@ export default function KeyboardPreview() {
   const pressedKeys = usePressedKeys();
 
   return (
-    <div className="h-[240px] w-full overflow-hidden rounded-2xl border border-highlight/20 bg-bgcolor-highlight/20">
+    <div className="h-[240px] w-full overflow-visible">
       <Canvas
         camera={{
           position: [0, 3.35, 5.35],

--- a/src/components/keyboard/index.tsx
+++ b/src/components/keyboard/index.tsx
@@ -91,12 +91,16 @@ function usePressedKeys() {
       });
     };
 
-    window.addEventListener("keydown", handleKeyDown);
-    window.addEventListener("keyup", handleKeyUp);
+    const clearPressedKeys = () => setPressedKeys(new Set());
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    window.addEventListener("keyup", handleKeyUp, true);
+    window.addEventListener("blur", clearPressedKeys);
 
     return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-      window.removeEventListener("keyup", handleKeyUp);
+      window.removeEventListener("keydown", handleKeyDown, true);
+      window.removeEventListener("keyup", handleKeyUp, true);
+      window.removeEventListener("blur", clearPressedKeys);
     };
   }, []);
 

--- a/src/components/keyboard/index.tsx
+++ b/src/components/keyboard/index.tsx
@@ -115,7 +115,7 @@ function KeyboardScene({ pressedKeys }: { pressedKeys: Set<KeyCode> }) {
       <ambientLight intensity={0.7} />
       <directionalLight position={[0, 5, 4]} intensity={1.45} castShadow />
       <Center>
-        <group>
+        <group rotation={[0.16, 0, 0]}>
           <RoundedBox
             args={[4.6, 0.22, 3.2]}
             radius={0.12}

--- a/src/components/keyboard/index.tsx
+++ b/src/components/keyboard/index.tsx
@@ -27,7 +27,7 @@ const KEY_LAYOUT: KeyboardKey[] = [
   {
     code: "Space",
     label: "Space",
-    position: [0, 0, 1.08],
+    position: [0, 0, 1.42],
     width: 3.2,
     depth: 0.8,
     row: 3,
@@ -117,10 +117,10 @@ function KeyboardScene({ pressedKeys }: { pressedKeys: Set<KeyCode> }) {
       <Center>
         <group rotation={[Math.PI / 4, 0, 0]}>
           <RoundedBox
-            args={[4.6, 0.22, 3.2]}
+            args={[4.6, 0.22, 3.9]}
             radius={0.12}
             smoothness={4}
-            position={[0, 0.05, 0.08]}
+            position={[0, 0.05, 0.22]}
             receiveShadow
           >
             <meshStandardMaterial
@@ -130,10 +130,10 @@ function KeyboardScene({ pressedKeys }: { pressedKeys: Set<KeyCode> }) {
             />
           </RoundedBox>
           <RoundedBox
-            args={[4.9, 0.18, 3.5]}
+            args={[4.9, 0.18, 4.2]}
             radius={0.14}
             smoothness={4}
-            position={[0, -0.1, 0.08]}
+            position={[0, -0.1, 0.22]}
             receiveShadow
           >
             <meshStandardMaterial

--- a/src/components/keyboard/index.tsx
+++ b/src/components/keyboard/index.tsx
@@ -1,4 +1,9 @@
-import { Center, ContactShadows, OrbitControls, RoundedBox } from "@react-three/drei";
+import {
+  Center,
+  ContactShadows,
+  OrbitControls,
+  RoundedBox,
+} from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import { useEffect, useState } from "react";
 import { Keycap } from "./keycap";
@@ -55,14 +60,15 @@ function usePressedKeys() {
         return;
       }
 
+      const keyCode = event.code;
       event.preventDefault();
       setPressedKeys((current) => {
-        if (current.has(event.code)) {
+        if (current.has(keyCode)) {
           return current;
         }
 
         const next = new Set(current);
-        next.add(event.code);
+        next.add(keyCode);
         return next;
       });
     };
@@ -72,14 +78,15 @@ function usePressedKeys() {
         return;
       }
 
+      const keyCode = event.code;
       event.preventDefault();
       setPressedKeys((current) => {
-        if (!current.has(event.code)) {
+        if (!current.has(keyCode)) {
           return current;
         }
 
         const next = new Set(current);
-        next.delete(event.code);
+        next.delete(keyCode);
         return next;
       });
     };

--- a/src/components/keyboard/index.tsx
+++ b/src/components/keyboard/index.tsx
@@ -16,19 +16,21 @@ interface KeyboardKey {
   position: [number, number, number];
   width?: number;
   depth?: number;
+  row?: number;
 }
 
 const KEY_LAYOUT: KeyboardKey[] = [
-  { code: "KeyW", label: "W", position: [0, 0, -1] },
-  { code: "KeyA", label: "A", position: [-1.05, 0, 0] },
-  { code: "KeyS", label: "S", position: [0, 0, 0] },
-  { code: "KeyD", label: "D", position: [1.05, 0, 0] },
+  { code: "KeyW", label: "W", position: [0, 0, -1.05], row: 1 },
+  { code: "KeyA", label: "A", position: [-1.05, 0, 0], row: 2 },
+  { code: "KeyS", label: "S", position: [0, 0, 0], row: 2 },
+  { code: "KeyD", label: "D", position: [1.05, 0, 0], row: 2 },
   {
     code: "Space",
     label: "Space",
-    position: [0, 0, 1.05],
+    position: [0, 0, 1.08],
     width: 3.2,
     depth: 0.8,
+    row: 3,
   },
 ];
 
@@ -111,9 +113,9 @@ function KeyboardScene({ pressedKeys }: { pressedKeys: Set<KeyCode> }) {
   return (
     <>
       <ambientLight intensity={0.7} />
-      <directionalLight position={[3, 5, 4]} intensity={1.4} castShadow />
+      <directionalLight position={[0, 5, 4]} intensity={1.45} castShadow />
       <Center>
-        <group rotation={[0, -0.22, 0]}>
+        <group>
           <RoundedBox
             args={[4.6, 0.22, 3.2]}
             radius={0.12}
@@ -147,6 +149,7 @@ function KeyboardScene({ pressedKeys }: { pressedKeys: Set<KeyCode> }) {
               position={key.position}
               width={key.width}
               depth={key.depth}
+              row={key.row}
               pressed={pressedKeys.has(key.code)}
             />
           ))}
@@ -171,8 +174,8 @@ export default function KeyboardPreview() {
     <div className="h-[240px] w-full overflow-hidden rounded-2xl border border-highlight/20 bg-bgcolor-highlight/20">
       <Canvas
         camera={{
-          position: [3.9, 3.2, 4.5],
-          fov: 42,
+          position: [0, 3.35, 5.35],
+          fov: 40,
         }}
         shadows
       >

--- a/src/components/keyboard/keycap.tsx
+++ b/src/components/keyboard/keycap.tsx
@@ -1,7 +1,7 @@
 import { RoundedBox, Text } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
-import { useRef } from "react";
-import type { Group } from "three";
+import { useMemo, useRef } from "react";
+import { BufferAttribute, BufferGeometry, type Group } from "three";
 
 interface KeycapProps {
   label: string;
@@ -11,9 +11,65 @@ interface KeycapProps {
   pressed: boolean;
 }
 
-const KEY_HEIGHT = 0.36;
-const REST_Y = 0.38;
-const PRESSED_Y = 0.06;
+const KEY_HEIGHT = 0.62;
+const TOP_SURFACE_HEIGHT = 0.12;
+const REST_Y = 0.52;
+const PRESSED_Y = 0.18;
+const TOP_INSET = 0.22;
+
+function createKeycapBodyGeometry(
+  width: number,
+  height: number,
+  depth: number
+) {
+  const topWidth = width - TOP_INSET;
+  const topDepth = depth - TOP_INSET;
+  const bottomX = width / 2;
+  const bottomZ = depth / 2;
+  const topX = topWidth / 2;
+  const topZ = topDepth / 2;
+  const bottomY = -height / 2;
+  const topY = height / 2;
+
+  const positions = new Float32Array([
+    -bottomX,
+    bottomY,
+    -bottomZ,
+    bottomX,
+    bottomY,
+    -bottomZ,
+    bottomX,
+    bottomY,
+    bottomZ,
+    -bottomX,
+    bottomY,
+    bottomZ,
+    -topX,
+    topY,
+    -topZ,
+    topX,
+    topY,
+    -topZ,
+    topX,
+    topY,
+    topZ,
+    -topX,
+    topY,
+    topZ,
+  ]);
+
+  const indices = [
+    0, 1, 5, 0, 5, 4, 1, 2, 6, 1, 6, 5, 2, 3, 7, 2, 7, 6, 3, 0, 4, 3, 4, 7, 4,
+    5, 6, 4, 6, 7, 3, 2, 1, 3, 1, 0,
+  ];
+
+  const geometry = new BufferGeometry();
+  geometry.setAttribute("position", new BufferAttribute(positions, 3));
+  geometry.setIndex(indices);
+  geometry.computeVertexNormals();
+
+  return geometry;
+}
 
 export function Keycap({
   label,
@@ -23,6 +79,12 @@ export function Keycap({
   pressed,
 }: KeycapProps) {
   const groupRef = useRef<Group>(null);
+  const topWidth = width - TOP_INSET;
+  const topDepth = depth - TOP_INSET;
+  const bodyGeometry = useMemo(
+    () => createKeycapBodyGeometry(width, KEY_HEIGHT, depth),
+    [width, depth]
+  );
 
   useFrame((_, delta) => {
     if (!groupRef.current) {
@@ -41,10 +103,19 @@ export function Keycap({
 
   return (
     <group ref={groupRef} position={[position[0], REST_Y, position[2]]}>
+      <mesh geometry={bodyGeometry} castShadow receiveShadow>
+        <meshStandardMaterial
+          color={pressed ? "#8f9da3" : "#d3dee3"}
+          roughness={0.72}
+          metalness={0.04}
+        />
+      </mesh>
       <RoundedBox
-        args={[width, KEY_HEIGHT, depth]}
-        radius={0.08}
+        args={[topWidth, TOP_SURFACE_HEIGHT, topDepth]}
+        radius={0.07}
         smoothness={4}
+        position={[0, KEY_HEIGHT / 2 + TOP_SURFACE_HEIGHT / 2 - 0.02, 0]}
+        castShadow
       >
         <meshStandardMaterial
           color={pressed ? "#9aa8ae" : "#edf4f7"}
@@ -57,7 +128,7 @@ export function Keycap({
         fontSize={label === "Space" ? 0.18 : 0.28}
         anchorX="center"
         anchorY="middle"
-        position={[0, KEY_HEIGHT / 2 + 0.012, -0.05]}
+        position={[0, KEY_HEIGHT / 2 + TOP_SURFACE_HEIGHT + 0.005, -0.05]}
         rotation={[-Math.PI / 2, 0, 0]}
       >
         {label}

--- a/src/components/keyboard/keycap.tsx
+++ b/src/components/keyboard/keycap.tsx
@@ -13,7 +13,7 @@ interface KeycapProps {
 
 const KEY_HEIGHT = 0.36;
 const REST_Y = 0.38;
-const PRESSED_Y = 0.18;
+const PRESSED_Y = 0.06;
 
 export function Keycap({
   label,
@@ -30,7 +30,7 @@ export function Keycap({
     }
 
     const targetY = pressed ? PRESSED_Y : REST_Y;
-    const targetRotationX = pressed ? -0.08 : 0;
+    const targetRotationX = pressed ? -0.16 : 0;
     const smoothing = Math.min(1, delta * 18);
 
     groupRef.current.position.y +=
@@ -47,7 +47,7 @@ export function Keycap({
         smoothness={4}
       >
         <meshStandardMaterial
-          color={pressed ? "#d6e0e4" : "#edf4f7"}
+          color={pressed ? "#9aa8ae" : "#edf4f7"}
           roughness={0.65}
           metalness={0.05}
         />

--- a/src/components/keyboard/keycap.tsx
+++ b/src/components/keyboard/keycap.tsx
@@ -1,0 +1,63 @@
+import { RoundedBox, Text } from "@react-three/drei";
+import { useFrame } from "@react-three/fiber";
+import { useRef } from "react";
+import type { Group } from "three";
+
+interface KeycapProps {
+  label: string;
+  position: [number, number, number];
+  width?: number;
+  depth?: number;
+  pressed: boolean;
+}
+
+const KEY_HEIGHT = 0.36;
+const REST_Y = 0.38;
+const PRESSED_Y = 0.18;
+
+export function Keycap({
+  label,
+  position,
+  width = 0.9,
+  depth = 0.9,
+  pressed,
+}: KeycapProps) {
+  const groupRef = useRef<Group>(null);
+
+  useFrame((_, delta) => {
+    if (!groupRef.current) {
+      return;
+    }
+
+    const targetY = pressed ? PRESSED_Y : REST_Y;
+    const targetRotationX = pressed ? -0.08 : 0;
+    const smoothing = Math.min(1, delta * 18);
+
+    groupRef.current.position.y +=
+      (targetY - groupRef.current.position.y) * smoothing;
+    groupRef.current.rotation.x +=
+      (targetRotationX - groupRef.current.rotation.x) * smoothing;
+  });
+
+  return (
+    <group ref={groupRef} position={[position[0], REST_Y, position[2]]}>
+      <RoundedBox args={[width, KEY_HEIGHT, depth]} radius={0.08} smoothness={4}>
+        <meshStandardMaterial
+          color={pressed ? "#d6e0e4" : "#edf4f7"}
+          roughness={0.65}
+          metalness={0.05}
+        />
+      </RoundedBox>
+      <Text
+        color="#ef4438"
+        fontSize={label === "Space" ? 0.18 : 0.28}
+        anchorX="center"
+        anchorY="middle"
+        position={[0, KEY_HEIGHT / 2 + 0.012, -0.05]}
+        rotation={[-Math.PI / 2, 0, 0]}
+      >
+        {label}
+      </Text>
+    </group>
+  );
+}

--- a/src/components/keyboard/keycap.tsx
+++ b/src/components/keyboard/keycap.tsx
@@ -188,8 +188,8 @@ function createLegendTexture(label: string, width: number, depth: number) {
   context.fillStyle = edge;
   context.fillRect(0, 0, canvas.width, canvas.height);
 
-  context.fillStyle = "#ef4438";
-  context.font = `700 ${label === "Space" ? 28 : 46}px Arial, sans-serif`;
+  context.fillStyle = "#ff4328";
+  context.font = `800 ${label === "Space" ? 36 : 58}px Arial, sans-serif`;
   context.textAlign = "center";
   context.textBaseline = "middle";
   context.fillText(label, canvas.width / 2, canvas.height / 2);
@@ -227,7 +227,7 @@ export function Keycap({
         metalness: 0.04,
       }),
       new MeshStandardMaterial({
-        color: pressed ? "#9aa8ae" : "#ffffff",
+        color: pressed ? "#aab5ba" : "#ffffff",
         map: legendTexture,
         roughness: 0.65,
         metalness: 0.05,

--- a/src/components/keyboard/keycap.tsx
+++ b/src/components/keyboard/keycap.tsx
@@ -1,74 +1,204 @@
-import { RoundedBox, Text } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
 import { useMemo, useRef } from "react";
-import { BufferAttribute, BufferGeometry, type Group } from "three";
+import {
+  BufferAttribute,
+  BufferGeometry,
+  CanvasTexture,
+  type Group,
+  LinearFilter,
+  SRGBColorSpace,
+} from "three";
 
 interface KeycapProps {
   label: string;
   position: [number, number, number];
   width?: number;
   depth?: number;
+  row?: number;
   pressed: boolean;
 }
 
 const KEY_HEIGHT = 0.62;
-const TOP_SURFACE_HEIGHT = 0.12;
 const REST_Y = 0.52;
 const PRESSED_Y = 0.18;
-const TOP_INSET = 0.22;
+const TOP_INSET = 0.18;
+const CORNER_INSET = 0.12;
+const SIDE_COLOR = "#d2dde2";
+const PRESSED_SIDE_COLOR = "#8f9da3";
+
+type Point = [number, number, number];
+
+function getPointUv(
+  point: Point,
+  width: number,
+  depth: number
+): [number, number] {
+  return [point[0] / width + 0.5, 1 - (point[2] / depth + 0.5)];
+}
+
+function pushTriangle(
+  positions: number[],
+  uvs: number[],
+  a: Point,
+  b: Point,
+  c: Point,
+  width: number,
+  depth: number,
+  usePlanarUv = false
+) {
+  positions.push(...a, ...b, ...c);
+
+  if (usePlanarUv) {
+    uvs.push(...getPointUv(a, width, depth), ...getPointUv(b, width, depth));
+    uvs.push(...getPointUv(c, width, depth));
+    return;
+  }
+
+  uvs.push(0, 0, 1, 0, 1, 1);
+}
 
 function createKeycapBodyGeometry(
   width: number,
   height: number,
-  depth: number
+  depth: number,
+  row: number
 ) {
-  const topWidth = width - TOP_INSET;
-  const topDepth = depth - TOP_INSET;
   const bottomX = width / 2;
   const bottomZ = depth / 2;
-  const topX = topWidth / 2;
-  const topZ = topDepth / 2;
+  const topX = (width - TOP_INSET) / 2;
+  const topZ = (depth - TOP_INSET) / 2;
   const bottomY = -height / 2;
   const topY = height / 2;
+  const corner = Math.min(CORNER_INSET, topX * 0.4, topZ * 0.4);
+  const bottomCorner = Math.min(corner * 0.55, bottomX * 0.25, bottomZ * 0.25);
+  const rowSlope = row === 1 ? -0.04 : row === 3 ? 0.08 : 0.04;
 
-  const positions = new Float32Array([
-    -bottomX,
-    bottomY,
-    -bottomZ,
-    bottomX,
-    bottomY,
-    -bottomZ,
-    bottomX,
-    bottomY,
-    bottomZ,
-    -bottomX,
-    bottomY,
-    bottomZ,
-    -topX,
-    topY,
-    -topZ,
-    topX,
-    topY,
-    -topZ,
-    topX,
-    topY,
-    topZ,
-    -topX,
-    topY,
-    topZ,
-  ]);
-
-  const indices = [
-    0, 1, 5, 0, 5, 4, 1, 2, 6, 1, 6, 5, 2, 3, 7, 2, 7, 6, 3, 0, 4, 3, 4, 7, 4,
-    5, 6, 4, 6, 7, 3, 2, 1, 3, 1, 0,
+  const topPoints: Point[] = [
+    [-topX + corner, topY - rowSlope, -topZ],
+    [topX - corner, topY - rowSlope, -topZ],
+    [topX, topY - rowSlope * 0.5, -topZ + corner],
+    [topX, topY + rowSlope * 0.5, topZ - corner],
+    [topX - corner, topY + rowSlope, topZ],
+    [-topX + corner, topY + rowSlope, topZ],
+    [-topX, topY + rowSlope * 0.5, topZ - corner],
+    [-topX, topY - rowSlope * 0.5, -topZ + corner],
   ];
 
+  const bottomPoints: Point[] = [
+    [-bottomX + bottomCorner, bottomY, -bottomZ],
+    [bottomX - bottomCorner, bottomY, -bottomZ],
+    [bottomX, bottomY, -bottomZ + bottomCorner],
+    [bottomX, bottomY, bottomZ - bottomCorner],
+    [bottomX - bottomCorner, bottomY, bottomZ],
+    [-bottomX + bottomCorner, bottomY, bottomZ],
+    [-bottomX, bottomY, bottomZ - bottomCorner],
+    [-bottomX, bottomY, -bottomZ + bottomCorner],
+  ];
+
+  const positions: number[] = [];
+  const uvs: number[] = [];
+
+  for (let i = 0; i < topPoints.length; i++) {
+    const next = (i + 1) % topPoints.length;
+
+    pushTriangle(
+      positions,
+      uvs,
+      bottomPoints[i],
+      bottomPoints[next],
+      topPoints[next],
+      width,
+      depth
+    );
+    pushTriangle(
+      positions,
+      uvs,
+      bottomPoints[i],
+      topPoints[next],
+      topPoints[i],
+      width,
+      depth
+    );
+  }
+
+  const sideVertexCount = positions.length / 3;
+  const topCenter: Point = [0, topY, 0];
+
+  for (let i = 0; i < topPoints.length; i++) {
+    const next = (i + 1) % topPoints.length;
+
+    pushTriangle(
+      positions,
+      uvs,
+      topCenter,
+      topPoints[i],
+      topPoints[next],
+      width,
+      depth,
+      true
+    );
+  }
+
   const geometry = new BufferGeometry();
-  geometry.setAttribute("position", new BufferAttribute(positions, 3));
-  geometry.setIndex(indices);
+  geometry.setAttribute(
+    "position",
+    new BufferAttribute(new Float32Array(positions), 3)
+  );
+  geometry.setAttribute("uv", new BufferAttribute(new Float32Array(uvs), 2));
+  geometry.addGroup(0, sideVertexCount, 0);
+  geometry.addGroup(sideVertexCount, positions.length / 3 - sideVertexCount, 1);
   geometry.computeVertexNormals();
 
   return geometry;
+}
+
+function createLegendTexture(label: string, width: number, depth: number) {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+
+  const pxPerUnit = 192;
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.max(128, Math.round(width * pxPerUnit));
+  canvas.height = Math.max(128, Math.round(depth * pxPerUnit));
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    return undefined;
+  }
+
+  const topColor = "#edf4f7";
+  context.fillStyle = topColor;
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  const contour = context.createLinearGradient(0, 0, canvas.width, 0);
+  contour.addColorStop(0, "rgba(255,255,255,0.24)");
+  contour.addColorStop(0.42, "rgba(255,255,255,0)");
+  contour.addColorStop(0.7, "rgba(0,0,0,0.03)");
+  contour.addColorStop(1, "rgba(0,0,0,0.18)");
+  context.fillStyle = contour;
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  const edge = context.createLinearGradient(0, 0, 0, canvas.height);
+  edge.addColorStop(0, "rgba(255,255,255,0.22)");
+  edge.addColorStop(0.12, "rgba(255,255,255,0)");
+  edge.addColorStop(0.86, "rgba(0,0,0,0)");
+  edge.addColorStop(1, "rgba(0,0,0,0.14)");
+  context.fillStyle = edge;
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  context.fillStyle = "#ef4438";
+  context.font = `700 ${label === "Space" ? 28 : 46}px Arial, sans-serif`;
+  context.textAlign = "center";
+  context.textBaseline = "middle";
+  context.fillText(label, canvas.width / 2, canvas.height / 2);
+
+  const texture = new CanvasTexture(canvas);
+  texture.colorSpace = SRGBColorSpace;
+  texture.minFilter = LinearFilter;
+  texture.magFilter = LinearFilter;
+
+  return texture;
 }
 
 export function Keycap({
@@ -76,14 +206,17 @@ export function Keycap({
   position,
   width = 0.9,
   depth = 0.9,
+  row = 2,
   pressed,
 }: KeycapProps) {
   const groupRef = useRef<Group>(null);
-  const topWidth = width - TOP_INSET;
-  const topDepth = depth - TOP_INSET;
   const bodyGeometry = useMemo(
-    () => createKeycapBodyGeometry(width, KEY_HEIGHT, depth),
-    [width, depth]
+    () => createKeycapBodyGeometry(width, KEY_HEIGHT, depth, row),
+    [width, depth, row]
+  );
+  const legendTexture = useMemo(
+    () => createLegendTexture(label, width, depth),
+    [label, width, depth]
   );
 
   useFrame((_, delta) => {
@@ -105,34 +238,19 @@ export function Keycap({
     <group ref={groupRef} position={[position[0], REST_Y, position[2]]}>
       <mesh geometry={bodyGeometry} castShadow receiveShadow>
         <meshStandardMaterial
-          color={pressed ? "#8f9da3" : "#d3dee3"}
+          attach="material-0"
+          color={pressed ? PRESSED_SIDE_COLOR : SIDE_COLOR}
           roughness={0.72}
           metalness={0.04}
         />
-      </mesh>
-      <RoundedBox
-        args={[topWidth, TOP_SURFACE_HEIGHT, topDepth]}
-        radius={0.07}
-        smoothness={4}
-        position={[0, KEY_HEIGHT / 2 + TOP_SURFACE_HEIGHT / 2 - 0.02, 0]}
-        castShadow
-      >
         <meshStandardMaterial
+          attach="material-1"
           color={pressed ? "#9aa8ae" : "#edf4f7"}
+          map={legendTexture}
           roughness={0.65}
           metalness={0.05}
         />
-      </RoundedBox>
-      <Text
-        color="#ef4438"
-        fontSize={label === "Space" ? 0.18 : 0.28}
-        anchorX="center"
-        anchorY="middle"
-        position={[0, KEY_HEIGHT / 2 + TOP_SURFACE_HEIGHT + 0.005, -0.05]}
-        rotation={[-Math.PI / 2, 0, 0]}
-      >
-        {label}
-      </Text>
+      </mesh>
     </group>
   );
 }

--- a/src/components/keyboard/keycap.tsx
+++ b/src/components/keyboard/keycap.tsx
@@ -132,8 +132,8 @@ function createKeycapBodyGeometry(
       positions,
       uvs,
       topCenter,
-      topPoints[i],
       topPoints[next],
+      topPoints[i],
       width,
       depth,
       true

--- a/src/components/keyboard/keycap.tsx
+++ b/src/components/keyboard/keycap.tsx
@@ -6,6 +6,7 @@ import {
   CanvasTexture,
   type Group,
   LinearFilter,
+  MeshBasicMaterial,
   MeshStandardMaterial,
   SRGBColorSpace,
 } from "three";
@@ -226,11 +227,9 @@ export function Keycap({
         roughness: 0.72,
         metalness: 0.04,
       }),
-      new MeshStandardMaterial({
-        color: pressed ? "#aab5ba" : "#ffffff",
+      new MeshBasicMaterial({
+        color: pressed ? "#b7c0c5" : "#ffffff",
         map: legendTexture,
-        roughness: 0.65,
-        metalness: 0.05,
       }),
     ],
     [pressed, legendTexture]

--- a/src/components/keyboard/keycap.tsx
+++ b/src/components/keyboard/keycap.tsx
@@ -22,7 +22,7 @@ interface KeycapProps {
 
 const KEY_HEIGHT = 0.62;
 const REST_Y = 0.52;
-const PRESSED_Y = 0.18;
+const PRESSED_Y = 0.08;
 const TOP_INSET = 0.18;
 const CORNER_INSET = 0.12;
 const SIDE_COLOR = "#d2dde2";
@@ -189,8 +189,10 @@ function createLegendTexture(label: string, width: number, depth: number) {
   context.fillStyle = edge;
   context.fillRect(0, 0, canvas.width, canvas.height);
 
-  context.fillStyle = "#ff4328";
-  context.font = `800 ${label === "Space" ? 36 : 58}px Arial, sans-serif`;
+  context.shadowColor = "rgba(255, 67, 40, 0.35)";
+  context.shadowBlur = 3;
+  context.fillStyle = "#ff2f17";
+  context.font = `900 ${label === "Space" ? 44 : 72}px Arial, sans-serif`;
   context.textAlign = "center";
   context.textBaseline = "middle";
   context.fillText(label, canvas.width / 2, canvas.height / 2);
@@ -199,6 +201,7 @@ function createLegendTexture(label: string, width: number, depth: number) {
   texture.colorSpace = SRGBColorSpace;
   texture.minFilter = LinearFilter;
   texture.magFilter = LinearFilter;
+  texture.needsUpdate = true;
 
   return texture;
 }
@@ -228,7 +231,7 @@ export function Keycap({
         metalness: 0.04,
       }),
       new MeshBasicMaterial({
-        color: pressed ? "#b7c0c5" : "#ffffff",
+        color: pressed ? "#7f8c93" : "#ffffff",
         map: legendTexture,
       }),
     ],

--- a/src/components/keyboard/keycap.tsx
+++ b/src/components/keyboard/keycap.tsx
@@ -107,8 +107,8 @@ function createKeycapBodyGeometry(
       positions,
       uvs,
       bottomPoints[i],
-      bottomPoints[next],
       topPoints[next],
+      bottomPoints[next],
       width,
       depth
     );
@@ -116,8 +116,8 @@ function createKeycapBodyGeometry(
       positions,
       uvs,
       bottomPoints[i],
-      topPoints[next],
       topPoints[i],
+      topPoints[next],
       width,
       depth
     );

--- a/src/components/keyboard/keycap.tsx
+++ b/src/components/keyboard/keycap.tsx
@@ -6,6 +6,7 @@ import {
   CanvasTexture,
   type Group,
   LinearFilter,
+  MeshStandardMaterial,
   SRGBColorSpace,
 } from "three";
 
@@ -218,6 +219,22 @@ export function Keycap({
     () => createLegendTexture(label, width, depth),
     [label, width, depth]
   );
+  const materials = useMemo(
+    () => [
+      new MeshStandardMaterial({
+        color: pressed ? PRESSED_SIDE_COLOR : SIDE_COLOR,
+        roughness: 0.72,
+        metalness: 0.04,
+      }),
+      new MeshStandardMaterial({
+        color: pressed ? "#9aa8ae" : "#ffffff",
+        map: legendTexture,
+        roughness: 0.65,
+        metalness: 0.05,
+      }),
+    ],
+    [pressed, legendTexture]
+  );
 
   useFrame((_, delta) => {
     if (!groupRef.current) {
@@ -236,21 +253,12 @@ export function Keycap({
 
   return (
     <group ref={groupRef} position={[position[0], REST_Y, position[2]]}>
-      <mesh geometry={bodyGeometry} castShadow receiveShadow>
-        <meshStandardMaterial
-          attach="material-0"
-          color={pressed ? PRESSED_SIDE_COLOR : SIDE_COLOR}
-          roughness={0.72}
-          metalness={0.04}
-        />
-        <meshStandardMaterial
-          attach="material-1"
-          color={pressed ? "#9aa8ae" : "#edf4f7"}
-          map={legendTexture}
-          roughness={0.65}
-          metalness={0.05}
-        />
-      </mesh>
+      <mesh
+        geometry={bodyGeometry}
+        material={materials}
+        castShadow
+        receiveShadow
+      />
     </group>
   );
 }

--- a/src/components/keyboard/keycap.tsx
+++ b/src/components/keyboard/keycap.tsx
@@ -41,7 +41,11 @@ export function Keycap({
 
   return (
     <group ref={groupRef} position={[position[0], REST_Y, position[2]]}>
-      <RoundedBox args={[width, KEY_HEIGHT, depth]} radius={0.08} smoothness={4}>
+      <RoundedBox
+        args={[width, KEY_HEIGHT, depth]}
+        radius={0.08}
+        smoothness={4}
+      >
         <meshStandardMaterial
           color={pressed ? "#d6e0e4" : "#edf4f7"}
           roughness={0.65}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a standalone React Three Fiber keyboard preview for WASD and Space.
- Animate keycaps in response to physical keydown and keyup events.
- Show the keyboard preview only while playing, below the Stop playing button, replacing the previous instruction text.
- Refine keycaps with KeySim-inspired chamfered BufferGeometry, fixed front face winding, 30-degree tilt, transparent background, and no Space/ASD clipping.

## Testing
- `npm run lint`
- `npm run build`
- Browser walkthrough recording confirmed play-mode keyboard placement, no tinted background, 30-degree tilt, visible front faces, visible legends, no key clipping, and W/Space keypress animations.

[keyboard_30_degree_tilt_walkthrough_trimmed.mp4](https://cursor.com/agents/bc-b7070543-c1e1-4e1a-8bde-ea5ae0448d78/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkeyboard_30_degree_tilt_walkthrough_trimmed.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7070543-c1e1-4e1a-8bde-ea5ae0448d78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7070543-c1e1-4e1a-8bde-ea5ae0448d78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

