### PR TITLE
Add procedural fringe effect to the /world voxel scene.

### DIFF
--- a/pages/world.tsx
+++ b/pages/world.tsx
@@ -10,7 +10,7 @@ export default function WorldPage() {
 
   return (
     <main className={`flex h-screen w-screen ${inter.className} relative`}>
-      <World rotateWorld={false} interactiveMode={isPlaying} />
+      <World rotateWorld={false} interactiveMode={isPlaying} showFringe />
       <button
         onClick={() => setIsPlaying(!isPlaying)}
         className={clsx(

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -104,7 +104,7 @@ export default function Hero() {
           id="world"
         >
           <div>
-            <World size={0.8} interactiveMode={isPlaying} closeUp />
+            <World size={0.8} interactiveMode={isPlaying} closeUp showFringe />
           </div>
           <div className="hidden md:flex flex-col justify-start items-center text-center gap-5 pt-32">
             <button

--- a/src/components/world/fringe/fringe-layout.test.ts
+++ b/src/components/world/fringe/fringe-layout.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import { VoxelWorld } from "../../../game/world/world";
+import { loadWorldCellsFromString } from "../../../game/world/world-loader";
+import worldData from "../world-data";
+import { computeFringeLayout, FRINGE_CONFIG } from "./fringe-layout";
+
+const world = new VoxelWorld(loadWorldCellsFromString(worldData));
+
+function hasGridTile(
+  layout: ReturnType<typeof computeFringeLayout>,
+  x: number,
+  z: number
+): boolean {
+  return layout.gridTiles.some((tile) => tile.x === x && tile.z === z);
+}
+
+function hasWireframe(
+  layout: ReturnType<typeof computeFringeLayout>,
+  x: number,
+  y: number,
+  z: number
+): boolean {
+  return layout.wireframes.some(
+    (wireframe) => wireframe.x === x && wireframe.y === y && wireframe.z === z
+  );
+}
+
+describe("computeFringeLayout", () => {
+  it("covers all four perimeter edges including negative coords", () => {
+    const layout = computeFringeLayout(world);
+
+    expect(hasWireframe(layout, 10, 0, 5)).toBe(true);
+    expect(hasWireframe(layout, -1, 0, 5)).toBe(true);
+    expect(hasWireframe(layout, 5, 0, 10)).toBe(true);
+    expect(hasWireframe(layout, 5, 0, -1)).toBe(true);
+
+    expect(hasGridTile(layout, -2, 5)).toBe(true);
+    expect(hasGridTile(layout, 5, -2)).toBe(true);
+    expect(hasGridTile(layout, 12, 5)).toBe(true);
+    expect(hasGridTile(layout, 5, 12)).toBe(true);
+  });
+
+  it("fills all four corner quadrants without gaps", () => {
+    const layout = computeFringeLayout(world);
+    const { wireframeRows, gridRows } = FRINGE_CONFIG;
+    const maxX = 9;
+    const maxZ = 9;
+
+    const corners = [
+      { signX: 1, signZ: 1, baseX: maxX, baseZ: maxZ },
+      { signX: -1, signZ: 1, baseX: 0, baseZ: maxZ },
+      { signX: 1, signZ: -1, baseX: maxX, baseZ: 0 },
+      { signX: -1, signZ: -1, baseX: 0, baseZ: 0 },
+    ] as const;
+
+    for (const { signX, signZ, baseX, baseZ } of corners) {
+      const gaps: string[] = [];
+
+      for (let xRow = 0; xRow <= gridRows; xRow++) {
+        for (let zRow = 0; zRow <= gridRows; zRow++) {
+          if (xRow === 0 && zRow === 0) {
+            continue;
+          }
+
+          const x = baseX + signX * (wireframeRows + xRow);
+          const z = baseZ + signZ * (wireframeRows + zRow);
+          if (!hasGridTile(layout, x, z)) {
+            gaps.push(`${x},${z}`);
+          }
+        }
+      }
+
+      expect(gaps).toEqual([]);
+    }
+  });
+
+  it("limits back-edge wireframe height to top grass, ignoring leaves", () => {
+    const layout = computeFringeLayout(world);
+    const backWireframeYs = layout.wireframes
+      .filter((wireframe) => wireframe.x === -1 && wireframe.z === 0)
+      .map((wireframe) => wireframe.y)
+      .sort((a, b) => a - b);
+
+    expect(backWireframeYs).toEqual([0, 1, 2, 3, 4]);
+    expect(hasWireframe(layout, -1, 5, 0)).toBe(false);
+  });
+});

--- a/src/components/world/fringe/fringe-layout.test.ts
+++ b/src/components/world/fringe/fringe-layout.test.ts
@@ -81,7 +81,7 @@ describe("computeFringeLayout", () => {
       .map((wireframe) => wireframe.y)
       .sort((a, b) => a - b);
 
-    expect(backWireframeYs).toEqual([0, 1, 2, 3, 4]);
-    expect(hasWireframe(layout, -1, 5, 0)).toBe(false);
+    expect(backWireframeYs).toEqual([0, 1, 2, 3]);
+    expect(hasWireframe(layout, -1, 4, 0)).toBe(false);
   });
 });

--- a/src/components/world/fringe/fringe-layout.ts
+++ b/src/components/world/fringe/fringe-layout.ts
@@ -1,3 +1,4 @@
+import type { WorldBounds } from "../../../game/core/types";
 import type { VoxelWorld } from "../../../game/world/world";
 
 export interface FringeWireframe {
@@ -28,16 +29,96 @@ export const FRINGE_CONFIG = {
   minOpacity: 0.05,
 } as const;
 
-function getColumnTopY(
+type FringeAxis = "x" | "z";
+type FringeSign = 1 | -1;
+
+interface EdgeFringeConfig {
+  axis: FringeAxis;
+  sign: FringeSign;
+  anchor: number;
+  iterateMin: number;
+  iterateMax: number;
+  useGrassHeight: boolean;
+}
+
+function getHighestGrassY(
   world: VoxelWorld,
   x: number,
   z: number
 ): number | null {
-  return world.getHighestSolidCell(x, z);
+  const bounds = world.getBounds();
+  for (let y = bounds.max.y; y >= bounds.min.y; y--) {
+    if (world.getBlockAtCell(x, y, z).renderKey === "grass") {
+      return y;
+    }
+  }
+
+  return null;
+}
+
+function getHighestSolidExcludingLeaves(
+  world: VoxelWorld,
+  x: number,
+  z: number
+): number | null {
+  const bounds = world.getBounds();
+  for (let y = bounds.max.y; y >= bounds.min.y; y--) {
+    if (!world.isCellSolid(x, y, z)) {
+      continue;
+    }
+
+    if (world.getBlockAtCell(x, y, z).renderKey === "leaves") {
+      continue;
+    }
+
+    return y;
+  }
+
+  return null;
+}
+
+function getColumnTopY(
+  world: VoxelWorld,
+  x: number,
+  z: number,
+  useGrassHeight: boolean
+): number | null {
+  if (!useGrassHeight) {
+    return world.getHighestSolidCell(x, z);
+  }
+
+  return (
+    getHighestGrassY(world, x, z) ??
+    getHighestSolidExcludingLeaves(world, x, z)
+  );
 }
 
 function getWireframeMaxY(topY: number): number {
   return topY > 0 ? topY - 1 : 0;
+}
+
+function outwardCoord(
+  anchor: number,
+  sign: FringeSign,
+  offset: number
+): number {
+  return anchor + sign * offset;
+}
+
+function gridOpacityForRow(row: number): number {
+  return (
+    FRINGE_CONFIG.gridOpacityByRow[row - 1] ??
+    FRINGE_CONFIG.gridOpacityByRow.at(-1) ??
+    0.2
+  );
+}
+
+function wireframeOpacityForRow(row: number): number {
+  return (
+    FRINGE_CONFIG.wireframeOpacityByRow[row - 1] ??
+    FRINGE_CONFIG.wireframeOpacityByRow.at(-1) ??
+    1.0
+  );
 }
 
 function cellKey(x: number, y: number, z: number): string {
@@ -67,104 +148,126 @@ function addGridTile(
   gridTiles.set(`${x},${z}`, { x, z, opacity });
 }
 
-export function computeFringeLayout(world: VoxelWorld): FringeLayout {
-  const bounds = world.getBounds();
+function addEdgeFringe(
+  world: VoxelWorld,
+  wireframes: Map<string, FringeWireframe>,
+  gridTiles: Map<string, FringeGridTile>,
+  config: EdgeFringeConfig
+): void {
   const { wireframeRows, gridRows } = FRINGE_CONFIG;
-  const maxX = bounds.max.x;
-  const maxZ = bounds.max.z;
+  const { axis, sign, anchor, iterateMin, iterateMax, useGrassHeight } = config;
 
-  const wireframes = new Map<string, FringeWireframe>();
-  const gridTiles = new Map<string, FringeGridTile>();
-
-  for (let z = bounds.min.z; z <= maxZ; z++) {
-    const topY = getColumnTopY(world, maxX, z);
+  for (let i = iterateMin; i <= iterateMax; i++) {
+    const x = axis === "x" ? anchor : i;
+    const z = axis === "z" ? anchor : i;
+    const topY = getColumnTopY(world, x, z, useGrassHeight);
     if (topY === null) {
       continue;
     }
 
-    const maxWireframeY = getWireframeMaxY(topY);
+    const maxWireframeY = useGrassHeight ? topY : getWireframeMaxY(topY);
 
     for (let row = 1; row <= wireframeRows; row++) {
-      const opacity =
-        FRINGE_CONFIG.wireframeOpacityByRow[row - 1] ??
-        FRINGE_CONFIG.wireframeOpacityByRow.at(-1) ??
-        1.0;
+      const opacity = wireframeOpacityForRow(row);
+      const outward = outwardCoord(anchor, sign, row);
+      const wx = axis === "x" ? outward : x;
+      const wz = axis === "z" ? outward : z;
       for (let y = 0; y <= maxWireframeY; y++) {
-        addWireframe(wireframes, maxX + row, y, z, opacity);
+        addWireframe(wireframes, wx, y, wz, opacity);
       }
     }
 
     for (let row = 1; row <= gridRows; row++) {
-      const opacity =
-        FRINGE_CONFIG.gridOpacityByRow[row - 1] ??
-        FRINGE_CONFIG.gridOpacityByRow.at(-1) ??
-        0.2;
-      addGridTile(gridTiles, maxX + wireframeRows + row, z, opacity);
+      const opacity = gridOpacityForRow(row);
+      const outward = outwardCoord(anchor, sign, wireframeRows + row);
+      const gx = axis === "x" ? outward : x;
+      const gz = axis === "z" ? outward : z;
+      addGridTile(gridTiles, gx, gz, opacity);
     }
   }
+}
 
-  for (let x = bounds.min.x; x <= maxX; x++) {
-    const topY = getColumnTopY(world, x, maxZ);
-    if (topY === null) {
-      continue;
-    }
-
-    const maxWireframeY = getWireframeMaxY(topY);
-
-    for (let row = 1; row <= wireframeRows; row++) {
-      const opacity =
-        FRINGE_CONFIG.wireframeOpacityByRow[row - 1] ??
-        FRINGE_CONFIG.wireframeOpacityByRow.at(-1) ??
-        1.0;
-      for (let y = 0; y <= maxWireframeY; y++) {
-        addWireframe(wireframes, x, y, maxZ + row, opacity);
-      }
-    }
-
-    for (let row = 1; row <= gridRows; row++) {
-      const opacity =
-        FRINGE_CONFIG.gridOpacityByRow[row - 1] ??
-        FRINGE_CONFIG.gridOpacityByRow.at(-1) ??
-        0.2;
-      addGridTile(gridTiles, x, maxZ + wireframeRows + row, opacity);
-    }
-  }
+function addCornerFringe(
+  gridTiles: Map<string, FringeGridTile>,
+  signX: FringeSign,
+  signZ: FringeSign,
+  bounds: WorldBounds
+): void {
+  const { wireframeRows, gridRows } = FRINGE_CONFIG;
+  const anchorX = signX === 1 ? bounds.max.x : bounds.min.x;
+  const anchorZ = signZ === 1 ? bounds.max.z : bounds.min.z;
 
   for (let xRow = 1; xRow <= gridRows; xRow++) {
     for (let zRow = 1; zRow <= gridRows; zRow++) {
       const row = Math.max(xRow, zRow);
-      const opacity =
-        FRINGE_CONFIG.gridOpacityByRow[row - 1] ??
-        FRINGE_CONFIG.gridOpacityByRow.at(-1) ??
-        0.2;
       addGridTile(
         gridTiles,
-        maxX + wireframeRows + xRow,
-        maxZ + wireframeRows + zRow,
-        opacity
+        outwardCoord(anchorX, signX, wireframeRows + xRow),
+        outwardCoord(anchorZ, signZ, wireframeRows + zRow),
+        gridOpacityForRow(row)
       );
     }
   }
 
-  // Bridge the +x and +z arms (they only cover z<=maxZ and x<=maxX respectively).
   for (let row = 1; row <= gridRows; row++) {
-    const opacity =
-      FRINGE_CONFIG.gridOpacityByRow[row - 1] ??
-      FRINGE_CONFIG.gridOpacityByRow.at(-1) ??
-      0.2;
+    const opacity = gridOpacityForRow(row);
     addGridTile(
       gridTiles,
-      maxX + wireframeRows + row,
-      maxZ + wireframeRows,
+      outwardCoord(anchorX, signX, wireframeRows + row),
+      outwardCoord(anchorZ, signZ, wireframeRows),
       opacity
     );
     addGridTile(
       gridTiles,
-      maxX + wireframeRows,
-      maxZ + wireframeRows + row,
+      outwardCoord(anchorX, signX, wireframeRows),
+      outwardCoord(anchorZ, signZ, wireframeRows + row),
       opacity
     );
   }
+}
+
+export function computeFringeLayout(world: VoxelWorld): FringeLayout {
+  const bounds = world.getBounds();
+  const wireframes = new Map<string, FringeWireframe>();
+  const gridTiles = new Map<string, FringeGridTile>();
+
+  addEdgeFringe(world, wireframes, gridTiles, {
+    axis: "x",
+    sign: 1,
+    anchor: bounds.max.x,
+    iterateMin: bounds.min.z,
+    iterateMax: bounds.max.z,
+    useGrassHeight: false,
+  });
+  addEdgeFringe(world, wireframes, gridTiles, {
+    axis: "x",
+    sign: -1,
+    anchor: bounds.min.x,
+    iterateMin: bounds.min.z,
+    iterateMax: bounds.max.z,
+    useGrassHeight: true,
+  });
+  addEdgeFringe(world, wireframes, gridTiles, {
+    axis: "z",
+    sign: 1,
+    anchor: bounds.max.z,
+    iterateMin: bounds.min.x,
+    iterateMax: bounds.max.x,
+    useGrassHeight: false,
+  });
+  addEdgeFringe(world, wireframes, gridTiles, {
+    axis: "z",
+    sign: -1,
+    anchor: bounds.min.z,
+    iterateMin: bounds.min.x,
+    iterateMax: bounds.max.x,
+    useGrassHeight: true,
+  });
+
+  addCornerFringe(gridTiles, 1, 1, bounds);
+  addCornerFringe(gridTiles, -1, 1, bounds);
+  addCornerFringe(gridTiles, 1, -1, bounds);
+  addCornerFringe(gridTiles, -1, -1, bounds);
 
   return {
     wireframes: Array.from(wireframes.values()),

--- a/src/components/world/fringe/fringe-layout.ts
+++ b/src/components/world/fringe/fringe-layout.ts
@@ -165,7 +165,7 @@ function addEdgeFringe(
       continue;
     }
 
-    const maxWireframeY = useGrassHeight ? topY : getWireframeMaxY(topY);
+    const maxWireframeY = getWireframeMaxY(topY);
 
     for (let row = 1; row <= wireframeRows; row++) {
       const opacity = wireframeOpacityForRow(row);

--- a/src/components/world/fringe/fringe-layout.ts
+++ b/src/components/world/fringe/fringe-layout.ts
@@ -1,0 +1,174 @@
+import type { VoxelWorld } from "../../../game/world/world";
+
+export interface FringeWireframe {
+  x: number;
+  y: number;
+  z: number;
+  opacity: number;
+}
+
+export interface FringeGridTile {
+  x: number;
+  z: number;
+  opacity: number;
+}
+
+export interface FringeLayout {
+  wireframes: FringeWireframe[];
+  gridTiles: FringeGridTile[];
+  gridY: number;
+}
+
+export const FRINGE_CONFIG = {
+  wireframeRows: 1,
+  gridRows: 3,
+  gridY: 0,
+  wireframeOpacityByRow: [1.0],
+  gridOpacityByRow: [1.0, 0.55, 0.2],
+  minOpacity: 0.05,
+} as const;
+
+function getColumnTopY(
+  world: VoxelWorld,
+  x: number,
+  z: number
+): number | null {
+  return world.getHighestSolidCell(x, z);
+}
+
+function getWireframeMaxY(topY: number): number {
+  return topY > 0 ? topY - 1 : 0;
+}
+
+function cellKey(x: number, y: number, z: number): string {
+  return `${x},${y},${z}`;
+}
+
+function addWireframe(
+  wireframes: Map<string, FringeWireframe>,
+  x: number,
+  y: number,
+  z: number,
+  opacity: number
+): void {
+  wireframes.set(cellKey(x, y, z), { x, y, z, opacity });
+}
+
+function addGridTile(
+  gridTiles: Map<string, FringeGridTile>,
+  x: number,
+  z: number,
+  opacity: number
+): void {
+  if (opacity < FRINGE_CONFIG.minOpacity) {
+    return;
+  }
+
+  gridTiles.set(`${x},${z}`, { x, z, opacity });
+}
+
+export function computeFringeLayout(world: VoxelWorld): FringeLayout {
+  const bounds = world.getBounds();
+  const { wireframeRows, gridRows } = FRINGE_CONFIG;
+  const maxX = bounds.max.x;
+  const maxZ = bounds.max.z;
+
+  const wireframes = new Map<string, FringeWireframe>();
+  const gridTiles = new Map<string, FringeGridTile>();
+
+  for (let z = bounds.min.z; z <= maxZ; z++) {
+    const topY = getColumnTopY(world, maxX, z);
+    if (topY === null) {
+      continue;
+    }
+
+    const maxWireframeY = getWireframeMaxY(topY);
+
+    for (let row = 1; row <= wireframeRows; row++) {
+      const opacity =
+        FRINGE_CONFIG.wireframeOpacityByRow[row - 1] ??
+        FRINGE_CONFIG.wireframeOpacityByRow.at(-1) ??
+        1.0;
+      for (let y = 0; y <= maxWireframeY; y++) {
+        addWireframe(wireframes, maxX + row, y, z, opacity);
+      }
+    }
+
+    for (let row = 1; row <= gridRows; row++) {
+      const opacity =
+        FRINGE_CONFIG.gridOpacityByRow[row - 1] ??
+        FRINGE_CONFIG.gridOpacityByRow.at(-1) ??
+        0.2;
+      addGridTile(gridTiles, maxX + wireframeRows + row, z, opacity);
+    }
+  }
+
+  for (let x = bounds.min.x; x <= maxX; x++) {
+    const topY = getColumnTopY(world, x, maxZ);
+    if (topY === null) {
+      continue;
+    }
+
+    const maxWireframeY = getWireframeMaxY(topY);
+
+    for (let row = 1; row <= wireframeRows; row++) {
+      const opacity =
+        FRINGE_CONFIG.wireframeOpacityByRow[row - 1] ??
+        FRINGE_CONFIG.wireframeOpacityByRow.at(-1) ??
+        1.0;
+      for (let y = 0; y <= maxWireframeY; y++) {
+        addWireframe(wireframes, x, y, maxZ + row, opacity);
+      }
+    }
+
+    for (let row = 1; row <= gridRows; row++) {
+      const opacity =
+        FRINGE_CONFIG.gridOpacityByRow[row - 1] ??
+        FRINGE_CONFIG.gridOpacityByRow.at(-1) ??
+        0.2;
+      addGridTile(gridTiles, x, maxZ + wireframeRows + row, opacity);
+    }
+  }
+
+  for (let xRow = 1; xRow <= gridRows; xRow++) {
+    for (let zRow = 1; zRow <= gridRows; zRow++) {
+      const row = Math.max(xRow, zRow);
+      const opacity =
+        FRINGE_CONFIG.gridOpacityByRow[row - 1] ??
+        FRINGE_CONFIG.gridOpacityByRow.at(-1) ??
+        0.2;
+      addGridTile(
+        gridTiles,
+        maxX + wireframeRows + xRow,
+        maxZ + wireframeRows + zRow,
+        opacity
+      );
+    }
+  }
+
+  // Bridge the +x and +z arms (they only cover z<=maxZ and x<=maxX respectively).
+  for (let row = 1; row <= gridRows; row++) {
+    const opacity =
+      FRINGE_CONFIG.gridOpacityByRow[row - 1] ??
+      FRINGE_CONFIG.gridOpacityByRow.at(-1) ??
+      0.2;
+    addGridTile(
+      gridTiles,
+      maxX + wireframeRows + row,
+      maxZ + wireframeRows,
+      opacity
+    );
+    addGridTile(
+      gridTiles,
+      maxX + wireframeRows,
+      maxZ + wireframeRows + row,
+      opacity
+    );
+  }
+
+  return {
+    wireframes: Array.from(wireframes.values()),
+    gridTiles: Array.from(gridTiles.values()),
+    gridY: FRINGE_CONFIG.gridY,
+  };
+}

--- a/src/components/world/fringe/fringe-renderer.tsx
+++ b/src/components/world/fringe/fringe-renderer.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from "react";
+import type { VoxelWorld } from "../../../game/world/world";
+import { computeFringeLayout } from "./fringe-layout";
+import GridTile from "./grid-tile";
+import WireframeBlock from "./wireframe-block";
+
+interface Props {
+  world: VoxelWorld;
+}
+
+export default function FringeRenderer({ world }: Props) {
+  const layout = useMemo(() => computeFringeLayout(world), [world]);
+
+  return (
+    <>
+      {layout.wireframes.map(({ x, y, z, opacity }) => (
+        <WireframeBlock
+          key={`wf-${x}-${y}-${z}`}
+          x={x}
+          y={y}
+          z={z}
+          opacity={opacity}
+        />
+      ))}
+      {layout.gridTiles.map(({ x, z, opacity }) => (
+        <GridTile
+          key={`gt-${x}-${z}`}
+          x={x}
+          z={z}
+          y={layout.gridY}
+          opacity={opacity}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/components/world/fringe/grid-tile.tsx
+++ b/src/components/world/fringe/grid-tile.tsx
@@ -1,0 +1,47 @@
+import { useLayoutEffect, useRef } from "react";
+import {
+  BufferGeometry,
+  Float32BufferAttribute,
+  type LineSegments,
+} from "three";
+
+interface Props {
+  x: number;
+  z: number;
+  y: number;
+  opacity: number;
+}
+
+function createTileGeometry(): BufferGeometry {
+  // Bottom face outline of a 1x1 block on the XZ plane (local y = 0).
+  const geometry = new BufferGeometry();
+  const vertices = new Float32Array([
+    0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0,
+  ]);
+
+  geometry.setAttribute("position", new Float32BufferAttribute(vertices, 3));
+  return geometry;
+}
+
+const tileGeometry = createTileGeometry();
+
+export default function GridTile({ x, z, y, opacity }: Props) {
+  const lineRef = useRef<LineSegments>(null);
+
+  useLayoutEffect(() => {
+    lineRef.current?.computeLineDistances();
+  }, []);
+
+  return (
+    <lineSegments ref={lineRef} geometry={tileGeometry} position={[x, y, z]}>
+      <lineDashedMaterial
+        color="#ffffff"
+        dashSize={0.12}
+        gapSize={0.08}
+        transparent
+        opacity={opacity}
+        depthWrite={false}
+      />
+    </lineSegments>
+  );
+}

--- a/src/components/world/fringe/wireframe-block.tsx
+++ b/src/components/world/fringe/wireframe-block.tsx
@@ -1,0 +1,21 @@
+import { BoxGeometry, EdgesGeometry } from "three";
+
+interface Props {
+  x: number;
+  y: number;
+  z: number;
+  opacity?: number;
+}
+
+const boxGeometry = new BoxGeometry(1, 1, 1);
+const edgesGeometry = new EdgesGeometry(boxGeometry);
+
+export default function WireframeBlock({ x, y, z, opacity = 0.9 }: Props) {
+  return (
+    <group position={[x, y, z]}>
+      <lineSegments geometry={edgesGeometry} position={[0.5, 0.5, 0.5]}>
+        <lineBasicMaterial color="#ffffff" transparent opacity={opacity} />
+      </lineSegments>
+    </group>
+  );
+}

--- a/src/components/world/index.tsx
+++ b/src/components/world/index.tsx
@@ -7,6 +7,7 @@ interface Props {
   rotateWorld?: boolean;
   interactiveMode?: boolean;
   closeUp?: boolean;
+  showFringe?: boolean;
 }
 
 function World({
@@ -14,6 +15,7 @@ function World({
   rotateWorld = true,
   interactiveMode = false,
   closeUp = false,
+  showFringe = false,
 }: Props) {
   return (
     <Canvas
@@ -51,6 +53,7 @@ function World({
         size={size}
         rotateWorld={rotateWorld}
         interactiveMode={interactiveMode}
+        showFringe={showFringe}
       />
     </Canvas>
   );

--- a/src/components/world/map.tsx
+++ b/src/components/world/map.tsx
@@ -7,6 +7,7 @@ import { vec3 } from "../../game/core/math/vec3";
 import { createGameState, type GameState } from "../../game/game";
 import { VoxelWorld } from "../../game/world/world";
 import { loadWorldCellsFromString } from "../../game/world/world-loader";
+import FringeRenderer from "./fringe/fringe-renderer";
 import Player from "./player";
 import worldData from "./world-data";
 
@@ -23,6 +24,7 @@ interface Props {
   size?: number;
   rotateWorld?: boolean;
   interactiveMode?: boolean;
+  showFringe?: boolean;
 }
 
 /**
@@ -32,6 +34,7 @@ export default function Map({
   size = 1,
   rotateWorld,
   interactiveMode = false,
+  showFringe = false,
 }: Props) {
   const playerRef = useRef<Group>(null);
   const worldRef = useRef<Group>(null);
@@ -104,6 +107,7 @@ export default function Map({
     <group ref={worldRef} scale={[size, size, size]}>
       <group position={[-4.5, 0, -4.5]}>
         <WorldRenderer world={world} />
+        {showFringe ? <FringeRenderer world={world} /> : null}
         <Player
           position={DEFAULT_PLAYER_POSITION}
           animate={!interactiveMode}


### PR DESCRIPTION
Wireframe stacks and fading dashed grid tiles extend from the island edges to suggest terrain still generating at the fringes.

Co-authored-by: Cursor <cursoragent@cursor.com>