### PR TITLE
Display project year in Things I've Built section

### DIFF
--- a/src/components/ProjectEntry.tsx
+++ b/src/components/ProjectEntry.tsx
@@ -62,6 +62,7 @@ export default function ProjectEntry({
   image,
   imageHeight,
   imageWidth,
+  year,
 }: Project) {
   const imageContainer = (
     <div
@@ -109,6 +110,11 @@ export default function ProjectEntry({
         ))}
       </div>
       <div className="flex flex-row justify-evenly mt-2">{links}</div>
+      {year != null && (
+        <div className="text-text-highlight font-bold text-xl mt-2 lg:group-odd:text-start lg:group-even:text-end text-center">
+          {year}
+        </div>
+      )}
     </div>
   );
 

--- a/src/components/ProjectEntry.tsx
+++ b/src/components/ProjectEntry.tsx
@@ -102,7 +102,7 @@ export default function ProjectEntry({
       <div className="mt-4 shadow-2xl bg-bgcolor-light rounded-sm flex flex-col lg:group-odd:text-start lg:group-even:text-end text-start">
         <div className="p-4">{description}</div>
         {year != null && (
-          <div className="text-text-highlight font-bold text-xl px-4 py-2 border-t border-text-faded/30 mt-auto">
+          <div className="text-text-highlight font-bold text-xl px-4 py-2 border-t border-text-faded/30 mt-auto text-center">
             {year}
           </div>
         )}

--- a/src/components/ProjectEntry.tsx
+++ b/src/components/ProjectEntry.tsx
@@ -99,8 +99,13 @@ export default function ProjectEntry({
     >
       <div className="text-4xl">{title}</div>
       <div className="text-text-faded text-xl">{subtitle}</div>
-      <div className="mt-4 p-4 shadow-2xl bg-bgcolor-light rounded-sm lg:group-odd:text-start lg:group-even:text-end text-start">
-        {description}
+      <div className="mt-4 shadow-2xl bg-bgcolor-light rounded-sm flex flex-col lg:group-odd:text-start lg:group-even:text-end text-start">
+        <div className="p-4">{description}</div>
+        {year != null && (
+          <div className="text-text-highlight font-bold text-xl px-4 py-2 border-t border-text-faded/30 mt-auto">
+            {year}
+          </div>
+        )}
       </div>
       <div className="mt-4 flex justify-evenly flex-wrap gap-3">
         {tags.map((tag, index) => (
@@ -110,11 +115,6 @@ export default function ProjectEntry({
         ))}
       </div>
       <div className="flex flex-row justify-evenly mt-2">{links}</div>
-      {year != null && (
-        <div className="text-text-highlight font-bold text-xl mt-2 lg:group-odd:text-start lg:group-even:text-end text-center">
-          {year}
-        </div>
-      )}
     </div>
   );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The "Things I've Built" portfolio entries now show each project's year as a footer on the description card, consistent with how years appear on archive project cards.

## Changes

- Updated `ProjectEntry` to render `year` inside the description card with a subtle top border
- Year sits at the bottom of the card (`mt-auto`) so it reads as a footer beneath the description text
- Removed the standalone year line that previously appeared below the project links

No config changes were needed — `src/config/projects.tsx` already had `year` values for t-ai (2023), Web Spinner (2023), and Synapse (2022).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34081fb6-ba5a-4294-8cc2-5b2e1a34e510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34081fb6-ba5a-4294-8cc2-5b2e1a34e510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

