### PR TITLE
Add procedural voxel world, LOD, chunk store, and renderer support

### DIFF
--- a/design-docs/1-world-refactor.md
+++ b/design-docs/1-world-refactor.md
@@ -2,6 +2,17 @@
 
 ## Goal
 
+## Non-negotiable preview seed invariant
+
+Preview mode must continue to render the current authored static map definition as the canonical seed. Procedural terrain is allowed to branch outward from that seed, but it must not replace, reinterpret, smooth, or mutate the authored 10x10 starter area. Any runtime/refactor work must preserve this rule:
+
+```text
+preview = authored static worldData seed + procedural continuation outside seed bounds
+interactive = same seed as origin + procedural continuation as player explores
+```
+
+This invariant applies to block lookup, render snapshots, collision, fringe layout, terrain blending, and camera/presentation behavior.
+
 Create a cleaner architecture for the procedural world so future changes do not keep accumulating inside `Map`, `ProceduralVoxelWorld`, and the fringe renderer.
 
 The current prototype proves that a procedural mode can work, but several responsibilities are mixed together:
@@ -117,6 +128,7 @@ This keeps seed logic out of the terrain generator internals.
 ## Acceptance criteria
 
 - `Map` no longer directly constructs `ProceduralVoxelWorld`.
+- Preview/starter rendering still uses the authored static `worldData` seed exactly.
 - `ProceduralVoxelWorld` only answers gameplay/world queries.
 - Preview anchoring and interactive following live in runtime/presentation modules.
 - Renderers consume explicit render snapshots instead of calling procedural world render helpers directly.

--- a/design-docs/1-world-refactor.md
+++ b/design-docs/1-world-refactor.md
@@ -1,0 +1,123 @@
+# 1. World Runtime Refactor Plan
+
+## Goal
+
+Create a cleaner architecture for the procedural world so future changes do not keep accumulating inside `Map`, `ProceduralVoxelWorld`, and the fringe renderer.
+
+The current prototype proves that a procedural mode can work, but several responsibilities are mixed together:
+
+- gameplay queries,
+- chunk loading,
+- terrain generation,
+- seeded-map preservation,
+- preview anchoring,
+- interactive focus following,
+- render footprint selection,
+- fringe layout,
+- player/camera presentation.
+
+This refactor should make those responsibilities explicit.
+
+## Target architecture
+
+```text
+World component
+  └─ Map component
+      └─ useWorldRuntime()
+          ├─ StaticWorldRuntime
+          └─ ProceduralWorldRuntime
+              ├─ ProceduralVoxelWorld      gameplay/block queries
+              ├─ TerrainPipeline           terrain generation
+              ├─ ChunkStore                chunk cache/lifecycle
+              ├─ LodPolicy                 fidelity classification
+              ├─ StarterRegion             seeded 10x10 map
+              └─ RenderSnapshot            render-ready terrain/fringe data
+```
+
+## New modules
+
+```text
+src/components/world/use-world-runtime.ts
+src/game/world/procedural/procedural-runtime.ts
+src/game/world/procedural/render-snapshot.ts
+src/game/world/procedural/starter-region.ts
+src/game/world/procedural/render-origin.ts
+```
+
+## Responsibility split
+
+### `ProceduralVoxelWorld`
+
+Keep this focused on `WorldQuery` behavior:
+
+- `getBlockIdAtCell`,
+- `getBlockAtCell`,
+- `getCollisionKind`,
+- `isCellSolid`,
+- `isCellFluid`,
+- `getFluidAdjacency`,
+- `getHighestSolidCell`,
+- `collidesAABB`.
+
+It should not decide how the world is rendered, how preview mode anchors, or how the camera follows.
+
+### `ProceduralWorldRuntime`
+
+Own runtime state:
+
+- current mode: preview or interactive,
+- focus position,
+- chunk window radius,
+- preview anchor,
+- interactive player-follow focus,
+- chunk ensure/evict calls,
+- render snapshot creation.
+
+### `RenderSnapshot`
+
+Bridge world simulation and rendering.
+
+Suggested shape:
+
+```ts
+interface ProceduralRenderSnapshot {
+  mode: "preview" | "interactive";
+  focus: { x: number; y: number; z: number };
+  renderOrigin: { x: number; y: number; z: number };
+  fullDetailBounds: WorldBounds;
+  highDetailCells: LoadedWorldCell[];
+  midDetailColumns: MidDetailColumn[];
+  wireColumns: WireColumn[];
+  gridTiles: FringeGridTile[];
+  particleTiles: FringeGridTile[];
+}
+```
+
+### `StarterRegion`
+
+Represent the existing 10x10 map as an authored starter region:
+
+- exact seeded block lookup,
+- seeded bounds,
+- seeded surface heights,
+- nearest seeded-edge lookup,
+- transition-skirt metadata.
+
+This keeps seed logic out of the terrain generator internals.
+
+## Implementation steps
+
+1. Add `StarterRegion` and move seed-cell indexing out of `TerrainGenerator`.
+2. Add `ProceduralWorldRuntime` and move mode/focus/chunk-window logic out of `ProceduralVoxelWorld`.
+3. Add `useWorldRuntime()` and move procedural/static world selection out of `Map`.
+4. Add `RenderSnapshot` and route procedural renderers through it.
+5. Keep static rendering unchanged until the procedural path is stable.
+6. Update tests so pure runtime functions are tested without React.
+
+## Acceptance criteria
+
+- `Map` no longer directly constructs `ProceduralVoxelWorld`.
+- `ProceduralVoxelWorld` only answers gameplay/world queries.
+- Preview anchoring and interactive following live in runtime/presentation modules.
+- Renderers consume explicit render snapshots instead of calling procedural world render helpers directly.
+- Static world mode continues to work unchanged.

--- a/design-docs/2-terrain-generation.md
+++ b/design-docs/2-terrain-generation.md
@@ -2,6 +2,15 @@
 
 ## Goal
 
+## Seed invariant
+
+The authored static map remains the source of truth for the preview/starter area. The procedural generator must branch off that map rather than regenerate it. In practice:
+
+- every existing `worldData` cell in the 10x10 seed must remain exact,
+- seeded column heights and block IDs must be read from the authored map,
+- smoothing and biome generation may only affect non-seeded columns,
+- generated columns adjacent to the seed should blend toward the seed edge instead of altering the seed.
+
 Replace the current simple column noise with a staged, Minecraft-like terrain pipeline that produces smoother height transitions and more coherent block/biome changes.
 
 Adjacent blocks should not abruptly change height or material unless the terrain intentionally enters a cliff/mountain feature.
@@ -112,7 +121,7 @@ Add or update tests in `src/game/world/procedural/procedural-world.test.ts`:
 - deterministic generation with same seed,
 - chunk boundary continuity,
 - neighboring generated column height delta stays within configured threshold,
-- seed cells remain exact,
+- seed cells remain exact and are never smoothed/replaced,
 - seed transition skirt does not create abrupt cliffs,
 - beach/grass/stone transitions do not create one-column spikes,
 - water level remains stable across adjacent columns.
@@ -121,5 +130,5 @@ Add or update tests in `src/game/world/procedural/procedural-world.test.ts`:
 
 - Adjacent generated columns rarely differ by more than 1-2 blocks except in classified cliffs.
 - Biome/material changes happen in bands rather than isolated cells.
-- The starter 10x10 map remains exact.
+- The starter 10x10 map remains exact and is the visible preview seed.
 - Terrain outside the starter map blends smoothly into the authored seed area.

--- a/design-docs/2-terrain-generation.md
+++ b/design-docs/2-terrain-generation.md
@@ -1,0 +1,125 @@
+# 2. Minecraft-Like Terrain Generation Plan
+
+## Goal
+
+Replace the current simple column noise with a staged, Minecraft-like terrain pipeline that produces smoother height transitions and more coherent block/biome changes.
+
+Adjacent blocks should not abruptly change height or material unless the terrain intentionally enters a cliff/mountain feature.
+
+## Current problem
+
+The current generator chooses height and biome directly from a small number of noise samples. This can cause:
+
+- abrupt height cliffs,
+- one-column material spikes,
+- harsh grass/sand/stone boundaries,
+- generated terrain that does not blend cleanly into the seeded 10x10 starter map.
+
+## Target generation pipeline
+
+```text
+seed
+  ↓
+climate fields
+  temperature, humidity, continentalness
+  ↓
+terrain fields
+  base height, erosion, peaks/valleys, detail
+  ↓
+biome selection
+  plains, beach, shallows, rocky hills, water
+  ↓
+height smoothing
+  neighborhood-aware pass with chunk borders
+  ↓
+surface material pass
+  grass/dirt/sand/stone/water by biome + slope + waterline
+  ↓
+chunk cell emission
+```
+
+## Proposed modules
+
+```text
+src/game/world/procedural/terrain/
+  noise.ts
+  climate.ts
+  heightfield.ts
+  biomes.ts
+  surface.ts
+  seed-transition.ts
+```
+
+## Terrain fields
+
+Use multiple low-frequency fields instead of one direct height function:
+
+- `continentalness`: controls land vs water mass.
+- `erosion`: lowers/smooths terrain and produces valleys.
+- `peaks`: raises hills/mountains.
+- `detail`: small local variation, applied after smoothing and clamped.
+
+Suggested height formula:
+
+```ts
+baseHeight = waterLevel + continentalness * 6;
+erodedHeight = baseHeight - erosion * 3;
+peakHeight = peaks > threshold ? (peaks - threshold) * 8 : 0;
+rawHeight = erodedHeight + peakHeight + detail;
+```
+
+Then apply a smoothing/quantization pass.
+
+## Height smoothing rules
+
+1. Generate each chunk with a border of at least one column around it.
+2. Smooth isolated pits/spikes.
+3. Clamp most neighboring column deltas to 1 or 2 blocks.
+4. Allow larger deltas only if a cliff classifier says the area is rocky/mountainous.
+5. Ensure chunk boundaries use the same samples so adjacent chunks match.
+
+## Biome and material transitions
+
+Biome selection should be gradual:
+
+- water/shallows near or below water level,
+- beach near waterline,
+- grassland inland,
+- rocky hills where slope/height are high.
+
+Surface material rules:
+
+- Waterline columns use sand near shore.
+- Grassland uses grass on top, dirt below, stone deeper.
+- Rocky slopes expose stone on steep or high terrain.
+- Transitions should be based on neighborhood/slope, not isolated random choice.
+
+## Seeded 10x10 starter region
+
+The existing map should remain exact inside the seeded area.
+
+Outside the seed, add a transition skirt:
+
+- `SEED_BLEND_RADIUS`, for example 8 columns.
+- Nearest seeded edge height influences generated height.
+- Generated terrain height is blended toward seeded edge height near the starter area.
+- Material preferences are blended from nearest seeded surface material.
+
+## Tests
+
+Add or update tests in `src/game/world/procedural/procedural-world.test.ts`:
+
+- deterministic generation with same seed,
+- chunk boundary continuity,
+- neighboring generated column height delta stays within configured threshold,
+- seed cells remain exact,
+- seed transition skirt does not create abrupt cliffs,
+- beach/grass/stone transitions do not create one-column spikes,
+- water level remains stable across adjacent columns.
+
+## Acceptance criteria
+
+- Adjacent generated columns rarely differ by more than 1-2 blocks except in classified cliffs.
+- Biome/material changes happen in bands rather than isolated cells.
+- The starter 10x10 map remains exact.
+- Terrain outside the starter map blends smoothly into the authored seed area.

--- a/design-docs/3-lod-render-snapshot.md
+++ b/design-docs/3-lod-render-snapshot.md
@@ -1,0 +1,123 @@
+# 3. LOD and Render Snapshot Plan
+
+## Goal
+
+Make LOD the single source of truth for what gets rendered as full blocks, mid-detail terrain, wireframes, grid, and particles.
+
+The current procedural path has high-detail blocks and a fringe perimeter, but it does not yet model a continuous fidelity transition.
+
+## Target fidelity bands
+
+```text
+10x10 full-detail footprint
+  → high-detail textured blocks
+near ring
+  → simplified/mid-detail terrain columns
+outer ring
+  → wireframe terrain columns
+horizon ring
+  → sparse grid and particles
+unloaded
+  → no render data
+```
+
+## LodPolicy responsibilities
+
+Extend `src/game/world/procedural/lod-policy.ts` so it can answer:
+
+```ts
+interface LodSample {
+  lod: "high" | "mid" | "wire" | "horizon" | "unloaded";
+  fidelity: number;
+  blockOpacity: number;
+  midOpacity: number;
+  wireOpacity: number;
+  particleOpacity: number;
+  distanceFromFullDetail: number;
+}
+```
+
+The policy should work at column/cell distance from the full-detail footprint, not only chunk distance.
+
+## Render snapshot
+
+Add `src/game/world/procedural/render-snapshot.ts`.
+
+Suggested types:
+
+```ts
+interface MidDetailColumn {
+  x: number;
+  z: number;
+  y: number;
+  height: number;
+  surfaceBlockId: number;
+  biome: BiomeId;
+  opacity: number;
+}
+
+interface WireColumn {
+  x: number;
+  z: number;
+  minY: number;
+  maxY: number;
+  opacity: number;
+  fidelity: number;
+}
+
+interface ProceduralRenderSnapshot {
+  highDetailCells: LoadedWorldCell[];
+  midDetailColumns: MidDetailColumn[];
+  wireColumns: WireColumn[];
+  gridTiles: FringeGridTile[];
+  particleTiles: FringeGridTile[];
+}
+```
+
+## Rendering layers
+
+### High detail
+
+Use the existing `WorldRenderer` path initially:
+
+- seeded 10x10 map,
+- fully textured blocks,
+- collision-authored terrain.
+
+Eventually replace per-block React rendering with chunk-instanced meshes.
+
+### Mid detail
+
+Add a simplified renderer:
+
+```text
+src/adapters/three/procedural-mid-detail-renderer.tsx
+```
+
+It should render:
+
+- top surfaces,
+- simplified side columns,
+- biome/surface color or existing texture,
+- fading opacity based on `LodSample.midOpacity`.
+
+### Wire/horizon
+
+Wireframe and grid should come from the same snapshot, not an independent perimeter calculation.
+
+## Implementation steps
+
+1. Extend `LodPolicy` with column-distance/fidelity helpers.
+2. Add `RenderSnapshot` types and builder.
+3. Make `ProceduralWorldRuntime` build snapshots from chunk data and LOD samples.
+4. Update `Map` to render snapshot layers.
+5. Keep static `WorldRenderer` unchanged.
+6. Add tests that snapshot classification matches LOD policy.
+
+## Acceptance criteria
+
+- Full blocks render only inside the high-detail footprint.
+- Mid-detail terrain appears outside full-detail blocks.
+- Wireframes appear outside mid-detail terrain.
+- Opacity/fidelity changes by distance instead of fixed hardcoded rows.
+- Terrain renderer and fringe renderer agree on LOD classification.

--- a/design-docs/3-lod-render-snapshot.md
+++ b/design-docs/3-lod-render-snapshot.md
@@ -2,6 +2,10 @@
 
 ## Goal
 
+## Seed/render invariant
+
+The high-detail preview/starter footprint is the authored static 10x10 map. Render snapshots must treat those seed cells as canonical high-detail cells and build mid-detail, wireframe, grid, and particle bands outward from that seed footprint. The LOD system should never swap the seed for generated terrain in preview mode.
+
 Make LOD the single source of truth for what gets rendered as full blocks, mid-detail terrain, wireframes, grid, and particles.
 
 The current procedural path has high-detail blocks and a fringe perimeter, but it does not yet model a continuous fidelity transition.
@@ -116,7 +120,7 @@ Wireframe and grid should come from the same snapshot, not an independent perime
 
 ## Acceptance criteria
 
-- Full blocks render only inside the high-detail footprint.
+- Full blocks render only inside the high-detail footprint, and the preview high-detail footprint is the authored static seed.
 - Mid-detail terrain appears outside full-detail blocks.
 - Wireframes appear outside mid-detail terrain.
 - Opacity/fidelity changes by distance instead of fixed hardcoded rows.

--- a/design-docs/4-fringe-wireframes.md
+++ b/design-docs/4-fringe-wireframes.md
@@ -2,6 +2,10 @@
 
 ## Goal
 
+## Seed/fringe invariant
+
+Procedural fringe bands must begin outside the authored static seed footprint. The current 10x10 map remains the high-fidelity seed in preview mode; wireframes, mid-detail terrain, and horizon effects are continuations that branch outward from that seed rather than replacements for it.
+
 Fix procedural fringe behavior so wireframes actually represent a low-fidelity frontier that resolves into higher-fidelity terrain near the render zone.
 
 The current procedural fringe is effectively a fixed perimeter around the 10x10 footprint. It does not fade out of fidelity at the edge or become higher fidelity as it approaches the rendered area.
@@ -104,6 +108,6 @@ Update `src/components/world/fringe/procedural-fringe-layout.test.ts`:
 ## Acceptance criteria
 
 - Wireframes are not visually fixed around the map.
-- Near terrain resolves into blocks/mid-detail rather than staying wireframe.
+- Near generated terrain resolves into blocks/mid-detail while the authored seed remains high fidelity.
 - Far terrain fades to grid/particles.
 - Static fringe behavior remains unchanged.

--- a/design-docs/4-fringe-wireframes.md
+++ b/design-docs/4-fringe-wireframes.md
@@ -1,0 +1,109 @@
+# 4. Fringe Wireframe and Fidelity Transition Plan
+
+## Goal
+
+Fix procedural fringe behavior so wireframes actually represent a low-fidelity frontier that resolves into higher-fidelity terrain near the render zone.
+
+The current procedural fringe is effectively a fixed perimeter around the 10x10 footprint. It does not fade out of fidelity at the edge or become higher fidelity as it approaches the rendered area.
+
+## Desired behavior
+
+Approaching the full-detail zone:
+
+```text
+horizon particles/grid
+  → wireframe terrain columns
+  → translucent mid-detail columns
+  → fully rendered blocks
+```
+
+Leaving the full-detail zone:
+
+```text
+fully rendered blocks
+  → mid-detail columns
+  → wireframe columns
+  → sparse grid/particles
+```
+
+## Problems to solve
+
+- Procedural wireframes use mostly fixed opacity.
+- Fringe layout is derived from `world.getBounds()` rather than LOD bands.
+- The shader only performs camera/back/lateral fade.
+- No per-line fidelity attribute exists.
+- Grid rows and particles are not tied to terrain LOD.
+
+## Layout changes
+
+Refactor `src/components/world/fringe/procedural-fringe-layout.ts` to consume render snapshot or LOD samples.
+
+Suggested `FringeWireframe` additions:
+
+```ts
+interface FringeWireframe {
+  x: number;
+  y: number;
+  z: number;
+  opacity: number;
+  fidelity?: number;
+  distanceBand?: number;
+}
+```
+
+Suggested `FringeGridTile` additions:
+
+```ts
+interface FringeGridTile {
+  x: number;
+  z: number;
+  opacity: number;
+  row: number;
+  outward: [number, number];
+  emissionWeight: number;
+  fidelity?: number;
+}
+```
+
+## Geometry changes
+
+Update `src/components/world/fringe/fringe-line-geometry.ts`:
+
+- add `fidelity` buffer attribute,
+- add `distanceBand` buffer attribute,
+- continue supporting static layout defaults.
+
+## Shader changes
+
+Update `src/components/world/fringe/fringe-line-field.tsx`:
+
+- read `fidelity` and/or `distanceBand`,
+- multiply opacity by LOD-derived fade,
+- optionally pulse low-fidelity wireframes,
+- keep existing camera-facing fade.
+
+## Particle changes
+
+Particle emission should derive from the far/horizon band:
+
+- no particles in full-detail or mid-detail areas,
+- more particles in horizon/grid rows,
+- disabled or low budget in preview mode,
+- enabled in interactive mode only if budget allows.
+
+## Tests
+
+Update `src/components/world/fringe/procedural-fringe-layout.test.ts`:
+
+- inner wire band starts outside full-detail footprint,
+- wire opacity changes by distance,
+- horizon/grid opacity fades out,
+- no fixed opacity for every procedural wireframe,
+- particle tiles come only from horizon/far bands.
+
+## Acceptance criteria
+
+- Wireframes are not visually fixed around the map.
+- Near terrain resolves into blocks/mid-detail rather than staying wireframe.
+- Far terrain fades to grid/particles.
+- Static fringe behavior remains unchanged.

--- a/design-docs/5-camera-presentation.md
+++ b/design-docs/5-camera-presentation.md
@@ -2,6 +2,10 @@
 
 ## Goal
 
+## Preview seed invariant
+
+Preview presentation must keep the authored static seed as the stable visual anchor. The player/autoplay can move within that fixed seed scene, while procedural terrain branches outward beyond the seed. Interactive camera-follow or render-origin behavior must not change the authored preview seed layout.
+
 Prevent the player from going off screen in interactive mode while preserving the current portfolio-style preview behavior.
 
 Preview and interactive mode should have different presentation rules.
@@ -96,7 +100,7 @@ Interactive mode should keep the player visible:
 
 ## Acceptance criteria
 
-- In preview mode, the world looks like a fixed portfolio scene.
+- In preview mode, the world looks like a fixed portfolio scene rooted in the authored static seed.
 - In interactive mode, the player stays in frame.
 - Procedural chunk focus follows the player only in interactive mode.
 - The system is ready for render-origin recentering without rewriting physics.

--- a/design-docs/5-camera-presentation.md
+++ b/design-docs/5-camera-presentation.md
@@ -1,0 +1,102 @@
+# 5. Camera and Presentation Mode Plan
+
+## Goal
+
+Prevent the player from going off screen in interactive mode while preserving the current portfolio-style preview behavior.
+
+Preview and interactive mode should have different presentation rules.
+
+## Desired mode behavior
+
+| Mode | Player | Camera / map | Purpose |
+| --- | --- | --- | --- |
+| Preview | Player/autoplay moves within staged scene | Map remains fixed or rotates | Portfolio preview |
+| Interactive | Player remains framed or centered | Camera follows or world recenters | Playable world |
+| Procedural infinite | Player drives chunk focus | Render origin follows player | Infinite terrain stability |
+
+## Short-term fix: follow camera
+
+Add a camera-follow helper for interactive mode.
+
+Suggested file:
+
+```text
+src/components/world/player-camera-follow.tsx
+```
+
+Behavior:
+
+- disabled in preview mode,
+- enabled in interactive mode,
+- reads `gameStateRef.current.player.position`,
+- lerps camera to a third-person offset,
+- calls `camera.lookAt(player.x, player.y + 1, player.z)`.
+
+Example camera offset:
+
+```ts
+const offset = { x: 8, y: 6, z: 8 };
+```
+
+## Long-term fix: render origin
+
+For infinite procedural terrain, use a render origin rather than rendering all objects at large simulation coordinates.
+
+Simulation coordinates remain real:
+
+```text
+player.position = world-space position
+collision uses world-space position
+chunks load around world-space position
+```
+
+Presentation coordinates are rebased:
+
+```text
+renderOrigin = player.position in interactive mode
+terrain renders at cell.position - renderOrigin
+player renders near visual center
+camera stays near visual center
+```
+
+Suggested file:
+
+```text
+src/game/world/procedural/render-origin.ts
+```
+
+## Preview rules
+
+Preview mode should not recenter on the player:
+
+- map remains fixed,
+- player/autoplay moves around the seeded 10x10 scene,
+- procedural focus can remain anchored to preview center,
+- no camera-follow behavior.
+
+## Interactive rules
+
+Interactive mode should keep the player visible:
+
+- initially use follow camera,
+- later switch procedural mode to player-centered render origin,
+- update procedural chunk focus from player simulation position,
+- keep world/collision simulation unchanged.
+
+## Implementation steps
+
+1. Add follow camera helper and enable it only in interactive mode.
+2. Add presentation mode type:
+   - `preview-fixed`,
+   - `interactive-follow-camera`,
+   - future `interactive-centered-origin`.
+3. Extract presentation selection into `useWorldRuntime()`.
+4. Add render-origin abstraction for procedural interactive mode.
+5. Update render snapshots to store both simulation coordinates and render-relative coordinates.
+
+## Acceptance criteria
+
+- In preview mode, the world looks like a fixed portfolio scene.
+- In interactive mode, the player stays in frame.
+- Procedural chunk focus follows the player only in interactive mode.
+- The system is ready for render-origin recentering without rewriting physics.

--- a/design-docs/6-implementation-roadmap.md
+++ b/design-docs/6-implementation-roadmap.md
@@ -1,0 +1,125 @@
+# 6. Implementation Roadmap
+
+## Recommended order
+
+### 1. Runtime refactor
+
+Implement `useWorldRuntime`, `ProceduralWorldRuntime`, `StarterRegion`, and `RenderSnapshot`.
+
+Why first:
+
+- reduces coupling,
+- gives terrain/fringe/camera work clean integration points,
+- prevents `Map` and `ProceduralVoxelWorld` from growing further.
+
+### 2. Short-term interactive camera follow
+
+Add an interactive follow camera before the render-origin system.
+
+Why second:
+
+- quickly fixes the player going off screen,
+- low risk,
+- does not block deeper architecture.
+
+### 3. LOD policy and render snapshot
+
+Make LOD classification and fidelity values shared between renderers and fringe.
+
+Why third:
+
+- fixes the fixed-fringe problem,
+- prepares mid-detail rendering,
+- makes procedural rendering deterministic and testable.
+
+### 4. Fringe fidelity refactor
+
+Use snapshot/LOD data to drive wireframe and grid opacity.
+
+Why fourth:
+
+- depends on LOD policy,
+- removes hardcoded procedural perimeter behavior.
+
+### 5. Minecraft-like terrain pipeline
+
+Refactor terrain generation into climate, heightfield, biome, surface, and seed-transition stages.
+
+Why fifth:
+
+- larger change,
+- easier once the runtime/snapshot boundaries exist,
+- can be tested mostly as pure functions.
+
+### 6. Mid-detail terrain renderer
+
+Add simplified terrain columns between full-detail blocks and wireframes.
+
+Why sixth:
+
+- depends on render snapshots and LOD fidelity,
+- completes the visual transition from wireframe to blocks.
+
+### 7. Player-centered render origin
+
+Replace or augment follow camera with render-origin recentering for infinite interactive terrain.
+
+Why seventh:
+
+- best long-term architecture,
+- easier after snapshots separate simulation and presentation coordinates.
+
+## Milestone checklist
+
+### Milestone A: Architecture foundation
+
+- [ ] `StarterRegion` owns seeded 10x10 map.
+- [ ] `ProceduralWorldRuntime` owns mode/focus/chunk window.
+- [ ] `RenderSnapshot` exists.
+- [ ] `Map` consumes runtime output.
+- [ ] Static mode still works.
+
+### Milestone B: Player framing
+
+- [ ] Interactive follow camera exists.
+- [ ] Preview mode remains fixed.
+- [ ] Reset key resets player and presentation state.
+
+### Milestone C: LOD/fringe
+
+- [ ] `LodPolicy` returns discrete LOD and continuous fidelity.
+- [ ] Procedural fringe consumes LOD/snapshot data.
+- [ ] Wireframe opacity changes by distance.
+- [ ] Particles only emit in far/horizon band.
+
+### Milestone D: Terrain quality
+
+- [ ] Heightfield smoothing implemented.
+- [ ] Biome transitions are gradual.
+- [ ] Seed transition skirt implemented.
+- [ ] Chunk boundary tests pass.
+
+### Milestone E: Render quality
+
+- [ ] Mid-detail renderer exists.
+- [ ] High/mid/wire/horizon bands transition smoothly.
+- [ ] Render origin supports infinite interactive movement.
+
+## Validation commands
+
+Run after each milestone:
+
+```bash
+bun run lint
+bun test
+bun run build
+```
+
+Manual validation:
+
+- preview mode remains stable,
+- interactive player stays framed,
+- seeded 10x10 area matches current map,
+- generated terrain does not cliff abruptly near seed,
+- wireframes fade from horizon into higher-fidelity terrain,
+- mobile WASD still controls the player on `/world`.

--- a/design-docs/6-implementation-roadmap.md
+++ b/design-docs/6-implementation-roadmap.md
@@ -2,6 +2,10 @@
 
 ## Recommended order
 
+## Global invariant
+
+All milestones must preserve this invariant: the current static `worldData` map is the exact preview/starter seed, and procedural generation branches outward from it. The seed must remain exact for rendering, collision, block lookup, LOD classification, and fringe placement.
+
 ### 1. Runtime refactor
 
 Implement `useWorldRuntime`, `ProceduralWorldRuntime`, `StarterRegion`, and `RenderSnapshot`.
@@ -73,7 +77,7 @@ Why seventh:
 
 ### Milestone A: Architecture foundation
 
-- [ ] `StarterRegion` owns seeded 10x10 map.
+- [ ] `StarterRegion` owns seeded 10x10 map and preserves it exactly.
 - [ ] `ProceduralWorldRuntime` owns mode/focus/chunk window.
 - [ ] `RenderSnapshot` exists.
 - [ ] `Map` consumes runtime output.
@@ -119,7 +123,7 @@ Manual validation:
 
 - preview mode remains stable,
 - interactive player stays framed,
-- seeded 10x10 area matches current map,
+- seeded 10x10 area exactly matches current static map,
 - generated terrain does not cliff abruptly near seed,
 - wireframes fade from horizon into higher-fidelity terrain,
 - mobile WASD still controls the player on `/world`.

--- a/pages/world.tsx
+++ b/pages/world.tsx
@@ -1,20 +1,102 @@
 import clsx from "clsx";
 import { Inter } from "next/font/google";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import World from "../src/components/world";
 
 const inter = Inter({ subsets: ["latin"] });
+
+type MobileControlKey = "KeyW" | "KeyA" | "KeyS" | "KeyD";
+
+interface MobileControlButton {
+  code: MobileControlKey;
+  label: string;
+  gridArea: string;
+}
+
+const mobileControls: MobileControlButton[] = [
+  { code: "KeyW", label: "W", gridArea: "col-start-2 row-start-1" },
+  { code: "KeyA", label: "A", gridArea: "col-start-1 row-start-2" },
+  { code: "KeyS", label: "S", gridArea: "col-start-2 row-start-2" },
+  { code: "KeyD", label: "D", gridArea: "col-start-3 row-start-2" },
+];
+
+function dispatchKeyboardControl(
+  code: MobileControlKey,
+  type: "keydown" | "keyup"
+) {
+  window.dispatchEvent(
+    new KeyboardEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      code,
+      key: code.replace("Key", "").toLowerCase(),
+    })
+  );
+}
+
+function MobileWasdControls({ enabled }: { enabled: boolean }) {
+  useEffect(() => {
+    if (!enabled) {
+      for (const control of mobileControls) {
+        dispatchKeyboardControl(control.code, "keyup");
+      }
+    }
+  }, [enabled]);
+
+  return (
+    <div
+      className={clsx(
+        "absolute bottom-24 left-4 z-20 grid grid-cols-3 grid-rows-2 gap-2 md:hidden select-none touch-none transition-opacity",
+        enabled ? "opacity-100" : "pointer-events-none opacity-40"
+      )}
+      role="group"
+      aria-label="Mobile WASD controls"
+    >
+      {mobileControls.map((control) => (
+        <button
+          key={control.code}
+          type="button"
+          aria-label={`Move ${control.label}`}
+          disabled={!enabled}
+          onPointerDown={(event) => {
+            event.preventDefault();
+            event.currentTarget.setPointerCapture(event.pointerId);
+            dispatchKeyboardControl(control.code, "keydown");
+          }}
+          onPointerUp={(event) => {
+            event.preventDefault();
+            dispatchKeyboardControl(control.code, "keyup");
+          }}
+          onPointerCancel={() => dispatchKeyboardControl(control.code, "keyup")}
+          onPointerLeave={() => dispatchKeyboardControl(control.code, "keyup")}
+          className={clsx(
+            control.gridArea,
+            "h-14 w-14 rounded-full border border-white/40 bg-black/70 text-lg font-bold text-white shadow-lg backdrop-blur-sm active:scale-95 disabled:cursor-not-allowed"
+          )}
+        >
+          {control.label}
+        </button>
+      ))}
+    </div>
+  );
+}
 
 export default function WorldPage() {
   const [isPlaying, setIsPlaying] = useState(false);
 
   return (
     <main className={`flex h-screen w-screen ${inter.className} relative`}>
-      <World rotateWorld={false} interactiveMode={isPlaying} showFringe />
+      <World
+        rotateWorld={false}
+        interactiveMode={isPlaying}
+        showFringe
+        worldMode="procedural"
+      />
+      <MobileWasdControls enabled={isPlaying} />
       <button
         onClick={() => setIsPlaying(!isPlaying)}
         className={clsx(
-          "absolute bottom-8 left-1/2 -translate-x-1/2 px-4 py-2 bg-yellow-500 text-black rounded-lg shadow-lg hover:bg-yellow-600 transition-all",
+          "absolute bottom-8 left-1/2 z-20 -translate-x-1/2 px-4 py-2 bg-yellow-500 text-black rounded-lg shadow-lg hover:bg-yellow-600 transition-all",
           {
             "animate-bounce": !isPlaying,
           }

--- a/src/adapters/three/world-renderer.tsx
+++ b/src/adapters/three/world-renderer.tsx
@@ -1,10 +1,13 @@
 import Block from "../../components/world/block";
 import { getRenderableBlockTextures } from "../../components/world/blocks";
 import { getBlockDefinition } from "../../game/world/block-registry";
-import type { VoxelWorld } from "../../game/world/world";
+import type { RenderableWorldQuery } from "../../game/world/world-query";
+
+export type WorldRenderDetail = "full" | "preview";
 
 interface Props {
-  world: VoxelWorld;
+  world: RenderableWorldQuery;
+  detail?: WorldRenderDetail;
 }
 
 const emptyFluidAdjacency = {
@@ -16,10 +19,15 @@ const emptyFluidAdjacency = {
   west: false,
 };
 
-export default function WorldRenderer({ world }: Props) {
+export default function WorldRenderer({ world, detail = "full" }: Props) {
+  const cells =
+    detail === "preview"
+      ? world.getExposedRenderableCells()
+      : world.getRenderableCells();
+
   return (
     <>
-      {world.getRenderableCells().map((cell) => {
+      {cells.map((cell) => {
         const block = getBlockDefinition(cell.id);
         const texture = getRenderableBlockTextures(block.renderKey);
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -111,6 +111,7 @@ export default function Hero() {
               interactiveMode={isPlaying}
               closeUp
               showFringe={isDesktop}
+              worldMode="procedural"
             />
           </div>
           <div className="hidden md:flex flex-col justify-start items-center text-center gap-5 pt-32">

--- a/src/components/world/fringe/fringe-layout.ts
+++ b/src/components/world/fringe/fringe-layout.ts
@@ -1,5 +1,5 @@
 import type { WorldBounds } from "../../../game/core/types";
-import type { VoxelWorld } from "../../../game/world/world";
+import type { RenderableWorldQuery } from "../../../game/world/world-query";
 import { computeOutwardVector } from "./fringe-animation";
 
 export interface FringeWireframe {
@@ -79,7 +79,7 @@ interface EdgeFringeConfig {
 }
 
 function getHighestGrassY(
-  world: VoxelWorld,
+  world: RenderableWorldQuery,
   x: number,
   z: number
 ): number | null {
@@ -94,7 +94,7 @@ function getHighestGrassY(
 }
 
 function getHighestSolidExcludingLeaves(
-  world: VoxelWorld,
+  world: RenderableWorldQuery,
   x: number,
   z: number
 ): number | null {
@@ -115,7 +115,7 @@ function getHighestSolidExcludingLeaves(
 }
 
 function getColumnTopY(
-  world: VoxelWorld,
+  world: RenderableWorldQuery,
   x: number,
   z: number,
   useGrassHeight: boolean
@@ -195,7 +195,7 @@ function addGridTile(
 }
 
 function addEdgeFringe(
-  world: VoxelWorld,
+  world: RenderableWorldQuery,
   wireframes: Map<string, FringeWireframe>,
   gridTiles: Map<string, FringeGridTile>,
   config: EdgeFringeConfig,
@@ -280,7 +280,7 @@ function addCornerFringe(
   }
 }
 
-export function computeFringeLayout(world: VoxelWorld): FringeLayout {
+export function computeFringeLayout(world: RenderableWorldQuery): FringeLayout {
   const bounds = world.getBounds();
   const centerX = (bounds.min.x + bounds.max.x + 1) / 2;
   const centerZ = (bounds.min.z + bounds.max.z + 1) / 2;

--- a/src/components/world/fringe/fringe-renderer.tsx
+++ b/src/components/world/fringe/fringe-renderer.tsx
@@ -1,15 +1,28 @@
 import { useMemo } from "react";
-import type { VoxelWorld } from "../../../game/world/world";
+import type { RenderableWorldQuery } from "../../../game/world/world-query";
 import { computeFringeLayout, FRINGE_CONFIG } from "./fringe-layout";
 import FringeLineField from "./fringe-line-field";
 import FringeParticleField from "./fringe-particles";
+import { computeProceduralFringeLayout } from "./procedural-fringe-layout";
 
 interface Props {
-  world: VoxelWorld;
+  world: RenderableWorldQuery;
+  enableParticles?: boolean;
+  procedural?: boolean;
 }
 
-export default function FringeRenderer({ world }: Props) {
-  const layout = useMemo(() => computeFringeLayout(world), [world]);
+export default function FringeRenderer({
+  world,
+  enableParticles = true,
+  procedural = false,
+}: Props) {
+  const layout = useMemo(
+    () =>
+      procedural
+        ? computeProceduralFringeLayout(world)
+        : computeFringeLayout(world),
+    [world, procedural]
+  );
   const particleTiles = useMemo(
     () =>
       layout.gridTiles.filter(
@@ -20,11 +33,13 @@ export default function FringeRenderer({ world }: Props) {
   return (
     <>
       <FringeLineField layout={layout} />
-      <FringeParticleField
-        tiles={particleTiles}
-        y={layout.gridY}
-        focus={layout.focus}
-      />
+      {enableParticles ? (
+        <FringeParticleField
+          tiles={particleTiles}
+          y={layout.gridY}
+          focus={layout.focus}
+        />
+      ) : null}
     </>
   );
 }

--- a/src/components/world/fringe/procedural-fringe-layout.test.ts
+++ b/src/components/world/fringe/procedural-fringe-layout.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { FULL_DETAIL_SIZE_XZ } from "../../../game/world/procedural/lod-policy";
+import { ProceduralVoxelWorld } from "../../../game/world/procedural/procedural-world";
+import { computeProceduralFringeLayout } from "./procedural-fringe-layout";
+
+describe("computeProceduralFringeLayout", () => {
+  it("starts wireframes immediately outside the 10x10 rendered footprint", () => {
+    const world = new ProceduralVoxelWorld({ seed: 23, mode: "preview" });
+    const bounds = world.getBounds();
+    const layout = computeProceduralFringeLayout(world);
+    const wireframeXs = new Set(
+      layout.wireframes.map((wireframe) => wireframe.x)
+    );
+    const wireframeZs = new Set(
+      layout.wireframes.map((wireframe) => wireframe.z)
+    );
+
+    expect(bounds.max.x - bounds.min.x + 1).toBe(FULL_DETAIL_SIZE_XZ);
+    expect(bounds.max.z - bounds.min.z + 1).toBe(FULL_DETAIL_SIZE_XZ);
+    expect(wireframeXs.has(bounds.min.x - 1)).toBe(true);
+    expect(wireframeXs.has(bounds.max.x + 1)).toBe(true);
+    expect(wireframeZs.has(bounds.min.z - 1)).toBe(true);
+    expect(wireframeZs.has(bounds.max.z + 1)).toBe(true);
+  });
+});

--- a/src/components/world/fringe/procedural-fringe-layout.ts
+++ b/src/components/world/fringe/procedural-fringe-layout.ts
@@ -1,0 +1,105 @@
+import { CHUNK_SIZE_XZ } from "../../../game/world/procedural/chunk-coords";
+import type { RenderableWorldQuery } from "../../../game/world/world-query";
+import { computeOutwardVector } from "./fringe-animation";
+import {
+  FRINGE_CONFIG,
+  type FringeGridTile,
+  type FringeLayout,
+  type FringeWireframe,
+} from "./fringe-layout";
+
+function cellKey(x: number, y: number, z: number): string {
+  return `${x},${y},${z}`;
+}
+
+function gridOpacityForRow(row: number): number {
+  return (
+    FRINGE_CONFIG.gridOpacityByRow[row - 1] ??
+    FRINGE_CONFIG.gridOpacityByRow.at(-1) ??
+    0.2
+  );
+}
+
+function addWireColumn(
+  wireframes: Map<string, FringeWireframe>,
+  world: RenderableWorldQuery,
+  x: number,
+  z: number,
+  opacity: number
+): void {
+  const topY = world.getHighestSolidCell(x, z);
+  if (topY === null) {
+    return;
+  }
+
+  const maxY = Math.max(0, topY - 1);
+  for (let y = 0; y <= maxY; y++) {
+    wireframes.set(cellKey(x, y, z), { x, y, z, opacity });
+  }
+}
+
+function addGridTile(
+  gridTiles: Map<string, FringeGridTile>,
+  x: number,
+  z: number,
+  row: number,
+  centerX: number,
+  centerZ: number
+): void {
+  const opacity = gridOpacityForRow(row);
+  if (opacity < FRINGE_CONFIG.minOpacity) {
+    return;
+  }
+
+  gridTiles.set(`${x},${z}`, {
+    x,
+    z,
+    opacity,
+    row,
+    outward: computeOutwardVector(x, z, centerX, centerZ),
+    emissionWeight: opacity,
+  });
+}
+
+export function computeProceduralFringeLayout(
+  world: RenderableWorldQuery
+): FringeLayout {
+  const bounds = world.getBounds();
+  const centerX = (bounds.min.x + bounds.max.x) / 2;
+  const centerZ = (bounds.min.z + bounds.max.z) / 2;
+  const minX = bounds.min.x + CHUNK_SIZE_XZ;
+  const maxX = bounds.max.x - CHUNK_SIZE_XZ;
+  const minZ = bounds.min.z + CHUNK_SIZE_XZ;
+  const maxZ = bounds.max.z - CHUNK_SIZE_XZ;
+  const wireframes = new Map<string, FringeWireframe>();
+  const gridTiles = new Map<string, FringeGridTile>();
+
+  for (let x = minX; x <= maxX; x++) {
+    addWireColumn(wireframes, world, x, minZ, 0.9);
+    addWireColumn(wireframes, world, x, maxZ, 0.9);
+  }
+
+  for (let z = minZ; z <= maxZ; z++) {
+    addWireColumn(wireframes, world, minX, z, 0.9);
+    addWireColumn(wireframes, world, maxX, z, 0.9);
+  }
+
+  for (let row = 1; row <= FRINGE_CONFIG.gridRows; row++) {
+    for (let x = minX - row; x <= maxX + row; x++) {
+      addGridTile(gridTiles, x, minZ - row, row, centerX, centerZ);
+      addGridTile(gridTiles, x, maxZ + row, row, centerX, centerZ);
+    }
+
+    for (let z = minZ - row; z <= maxZ + row; z++) {
+      addGridTile(gridTiles, minX - row, z, row, centerX, centerZ);
+      addGridTile(gridTiles, maxX + row, z, row, centerX, centerZ);
+    }
+  }
+
+  return {
+    wireframes: Array.from(wireframes.values()),
+    gridTiles: Array.from(gridTiles.values()),
+    gridY: FRINGE_CONFIG.gridY,
+    focus: { x: centerX, y: 0, z: centerZ },
+  };
+}

--- a/src/components/world/fringe/procedural-fringe-layout.ts
+++ b/src/components/world/fringe/procedural-fringe-layout.ts
@@ -1,4 +1,3 @@
-import { CHUNK_SIZE_XZ } from "../../../game/world/procedural/chunk-coords";
 import type { RenderableWorldQuery } from "../../../game/world/world-query";
 import { computeOutwardVector } from "./fringe-animation";
 import {
@@ -67,32 +66,41 @@ export function computeProceduralFringeLayout(
   const bounds = world.getBounds();
   const centerX = (bounds.min.x + bounds.max.x) / 2;
   const centerZ = (bounds.min.z + bounds.max.z) / 2;
-  const minX = bounds.min.x + CHUNK_SIZE_XZ;
-  const maxX = bounds.max.x - CHUNK_SIZE_XZ;
-  const minZ = bounds.min.z + CHUNK_SIZE_XZ;
-  const maxZ = bounds.max.z - CHUNK_SIZE_XZ;
+  const minX = bounds.min.x;
+  const maxX = bounds.max.x;
+  const minZ = bounds.min.z;
+  const maxZ = bounds.max.z;
+  const wireMinX = minX - 1;
+  const wireMaxX = maxX + 1;
+  const wireMinZ = minZ - 1;
+  const wireMaxZ = maxZ + 1;
   const wireframes = new Map<string, FringeWireframe>();
   const gridTiles = new Map<string, FringeGridTile>();
 
-  for (let x = minX; x <= maxX; x++) {
-    addWireColumn(wireframes, world, x, minZ, 0.9);
-    addWireColumn(wireframes, world, x, maxZ, 0.9);
+  for (let x = wireMinX; x <= wireMaxX; x++) {
+    addWireColumn(wireframes, world, x, wireMinZ, 0.9);
+    addWireColumn(wireframes, world, x, wireMaxZ, 0.9);
   }
 
-  for (let z = minZ; z <= maxZ; z++) {
-    addWireColumn(wireframes, world, minX, z, 0.9);
-    addWireColumn(wireframes, world, maxX, z, 0.9);
+  for (let z = wireMinZ; z <= wireMaxZ; z++) {
+    addWireColumn(wireframes, world, wireMinX, z, 0.9);
+    addWireColumn(wireframes, world, wireMaxX, z, 0.9);
   }
 
   for (let row = 1; row <= FRINGE_CONFIG.gridRows; row++) {
-    for (let x = minX - row; x <= maxX + row; x++) {
-      addGridTile(gridTiles, x, minZ - row, row, centerX, centerZ);
-      addGridTile(gridTiles, x, maxZ + row, row, centerX, centerZ);
+    const gridMinX = wireMinX - row;
+    const gridMaxX = wireMaxX + row;
+    const gridMinZ = wireMinZ - row;
+    const gridMaxZ = wireMaxZ + row;
+
+    for (let x = gridMinX; x <= gridMaxX; x++) {
+      addGridTile(gridTiles, x, gridMinZ, row, centerX, centerZ);
+      addGridTile(gridTiles, x, gridMaxZ, row, centerX, centerZ);
     }
 
-    for (let z = minZ - row; z <= maxZ + row; z++) {
-      addGridTile(gridTiles, minX - row, z, row, centerX, centerZ);
-      addGridTile(gridTiles, maxX + row, z, row, centerX, centerZ);
+    for (let z = gridMinZ; z <= gridMaxZ; z++) {
+      addGridTile(gridTiles, gridMinX, z, row, centerX, centerZ);
+      addGridTile(gridTiles, gridMaxX, z, row, centerX, centerZ);
     }
   }
 

--- a/src/components/world/index.tsx
+++ b/src/components/world/index.tsx
@@ -1,6 +1,6 @@
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
-import Map from "./map";
+import Map, { type WorldMode } from "./map";
 
 interface Props {
   size?: number;
@@ -8,6 +8,7 @@ interface Props {
   interactiveMode?: boolean;
   closeUp?: boolean;
   showFringe?: boolean;
+  worldMode?: WorldMode;
 }
 
 function World({
@@ -16,6 +17,7 @@ function World({
   interactiveMode = false,
   closeUp = false,
   showFringe = false,
+  worldMode = "static",
 }: Props) {
   return (
     <Canvas
@@ -26,13 +28,13 @@ function World({
       style={{
         height: closeUp ? "900px" : "100%",
       }}
-      shadows
+      shadows={interactiveMode}
     >
       <ambientLight intensity={0.5} />
       <directionalLight
         position={[1, 10, 5]}
         intensity={1}
-        castShadow
+        castShadow={interactiveMode}
         shadow-mapSize-width={1024}
         shadow-mapSize-height={1024}
         shadow-camera-near={0.5}
@@ -54,6 +56,7 @@ function World({
         rotateWorld={rotateWorld}
         interactiveMode={interactiveMode}
         showFringe={showFringe}
+        worldMode={worldMode}
       />
     </Canvas>
   );

--- a/src/components/world/map.tsx
+++ b/src/components/world/map.tsx
@@ -1,12 +1,15 @@
 import { useFrame } from "@react-three/fiber";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { Group } from "three";
 import { useKeyboardState } from "../../adapters/input/keyboard";
 import WorldRenderer from "../../adapters/three/world-renderer";
 import { vec3 } from "../../game/core/math/vec3";
 import { createGameState, type GameState } from "../../game/game";
+import type { ProceduralRuntimeMode } from "../../game/world/procedural/lod-policy";
+import { ProceduralVoxelWorld } from "../../game/world/procedural/procedural-world";
 import { VoxelWorld } from "../../game/world/world";
 import { loadWorldCellsFromString } from "../../game/world/world-loader";
+import type { RenderableWorldQuery } from "../../game/world/world-query";
 import FringeRenderer from "./fringe/fringe-renderer";
 import Player from "./player";
 import worldData from "./world-data";
@@ -20,11 +23,14 @@ const DEFAULT_PLAYER_STATE_POSITION = vec3(9.5, 6, 1.5);
 const DEFAULT_PLAYER_ROTATION: Vec3 = [0, 0, 0];
 const DEFAULT_WORLD_ROTATION: Vec3 = [0, 0, 0];
 
+export type WorldMode = "static" | "procedural";
+
 interface Props {
   size?: number;
   rotateWorld?: boolean;
   interactiveMode?: boolean;
   showFringe?: boolean;
+  worldMode?: WorldMode;
 }
 
 /**
@@ -35,25 +41,54 @@ export default function Map({
   rotateWorld,
   interactiveMode = false,
   showFringe = false,
+  worldMode = "static",
 }: Props) {
   const playerRef = useRef<Group>(null);
   const worldRef = useRef<Group>(null);
   const keyControlsRef = useKeyboardState();
+  const [, setRenderVersion] = useState(0);
+  const proceduralWorld = useMemo(
+    () => new ProceduralVoxelWorld({ seed: 2026, mode: "preview" }),
+    []
+  );
+  const isProcedural = worldMode === "procedural";
+  const activeWorld: RenderableWorldQuery = isProcedural
+    ? proceduralWorld
+    : world;
+  const proceduralSpawn = proceduralWorld.findSpawnColumn(0, 0);
+  const playerPosition = useMemo<Vec3>(
+    () =>
+      isProcedural
+        ? [proceduralSpawn.x, proceduralSpawn.y, proceduralSpawn.z]
+        : DEFAULT_PLAYER_POSITION,
+    [isProcedural, proceduralSpawn.x, proceduralSpawn.y, proceduralSpawn.z]
+  );
+  const playerStatePosition = useMemo(
+    () =>
+      isProcedural
+        ? vec3(
+            proceduralSpawn.x + 0.5,
+            proceduralSpawn.y,
+            proceduralSpawn.z + 0.5
+          )
+        : DEFAULT_PLAYER_STATE_POSITION,
+    [isProcedural, proceduralSpawn.x, proceduralSpawn.y, proceduralSpawn.z]
+  );
+  const runtimeMode: ProceduralRuntimeMode = interactiveMode
+    ? "interactive"
+    : "preview";
   const gameStateRef = useRef<GameState>(
-    createGameState(world, DEFAULT_PLAYER_STATE_POSITION)
+    createGameState(activeWorld, playerStatePosition)
   );
 
   function resetPlayer() {
-    gameStateRef.current = createGameState(
-      world,
-      DEFAULT_PLAYER_STATE_POSITION
-    );
+    gameStateRef.current = createGameState(activeWorld, playerStatePosition);
 
     if (playerRef.current) {
       playerRef.current.position.set(
-        DEFAULT_PLAYER_STATE_POSITION.x,
-        DEFAULT_PLAYER_STATE_POSITION.y,
-        DEFAULT_PLAYER_STATE_POSITION.z
+        playerStatePosition.x,
+        playerStatePosition.y,
+        playerStatePosition.z
       );
       playerRef.current.rotation.set(
         DEFAULT_PLAYER_ROTATION[0],
@@ -96,6 +131,18 @@ export default function Map({
     if (worldRef.current && rotateWorld && !interactiveMode) {
       worldRef.current.rotation.y += delta * ROTATION_SPEED;
     }
+
+    if (isProcedural) {
+      const { position } = gameStateRef.current.player;
+      const changed = proceduralWorld.updateFocus(
+        position.x,
+        position.z,
+        runtimeMode
+      );
+      if (changed) {
+        setRenderVersion((version) => version + 1);
+      }
+    }
   });
 
   useEffect(() => {
@@ -103,13 +150,32 @@ export default function Map({
     resetWorld();
   }, [interactiveMode]);
 
+  useEffect(() => {
+    gameStateRef.current = createGameState(activeWorld, playerStatePosition);
+    proceduralWorld.updateFocus(
+      playerStatePosition.x,
+      playerStatePosition.z,
+      runtimeMode
+    );
+    resetPlayer();
+  }, [activeWorld, playerStatePosition, proceduralWorld, runtimeMode]);
+
   return (
     <group ref={worldRef} scale={[size, size, size]}>
       <group position={[-4.5, 0, -4.5]}>
-        <WorldRenderer world={world} />
-        {showFringe ? <FringeRenderer world={world} /> : null}
+        <WorldRenderer
+          world={activeWorld}
+          detail={interactiveMode ? "full" : "preview"}
+        />
+        {showFringe ? (
+          <FringeRenderer
+            world={activeWorld}
+            enableParticles={interactiveMode}
+            procedural={isProcedural}
+          />
+        ) : null}
         <Player
-          position={DEFAULT_PLAYER_POSITION}
+          position={playerPosition}
           animate={!interactiveMode}
           gameStateRef={gameStateRef}
           ref={playerRef}

--- a/src/components/world/map.tsx
+++ b/src/components/world/map.tsx
@@ -14,7 +14,8 @@ import FringeRenderer from "./fringe/fringe-renderer";
 import Player from "./player";
 import worldData from "./world-data";
 
-const world = new VoxelWorld(loadWorldCellsFromString(worldData));
+const worldCells = loadWorldCellsFromString(worldData);
+const world = new VoxelWorld(worldCells);
 const ROTATION_SPEED = 0.3;
 
 type Vec3 = [number, number, number];
@@ -48,7 +49,14 @@ export default function Map({
   const keyControlsRef = useKeyboardState();
   const [, setRenderVersion] = useState(0);
   const proceduralWorld = useMemo(
-    () => new ProceduralVoxelWorld({ seed: 2026, mode: "preview" }),
+    () =>
+      new ProceduralVoxelWorld({
+        seed: 2026,
+        mode: "preview",
+        centerX: 5,
+        centerZ: 5,
+        seedCells: worldCells,
+      }),
     []
   );
   const isProcedural = worldMode === "procedural";

--- a/src/components/world/map.tsx
+++ b/src/components/world/map.tsx
@@ -63,25 +63,8 @@ export default function Map({
   const activeWorld: RenderableWorldQuery = isProcedural
     ? proceduralWorld
     : world;
-  const proceduralSpawn = proceduralWorld.findSpawnColumn(0, 0);
-  const playerPosition = useMemo<Vec3>(
-    () =>
-      isProcedural
-        ? [proceduralSpawn.x, proceduralSpawn.y, proceduralSpawn.z]
-        : DEFAULT_PLAYER_POSITION,
-    [isProcedural, proceduralSpawn.x, proceduralSpawn.y, proceduralSpawn.z]
-  );
-  const playerStatePosition = useMemo(
-    () =>
-      isProcedural
-        ? vec3(
-            proceduralSpawn.x + 0.5,
-            proceduralSpawn.y,
-            proceduralSpawn.z + 0.5
-          )
-        : DEFAULT_PLAYER_STATE_POSITION,
-    [isProcedural, proceduralSpawn.x, proceduralSpawn.y, proceduralSpawn.z]
-  );
+  const playerPosition = DEFAULT_PLAYER_POSITION;
+  const playerStatePosition = DEFAULT_PLAYER_STATE_POSITION;
   const runtimeMode: ProceduralRuntimeMode = interactiveMode
     ? "interactive"
     : "preview";

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -2,16 +2,16 @@ import type { Vec3 } from "./core/math/vec3";
 import type { PlayerInputFrame } from "./core/types";
 import { createPlayerState, type PlayerState } from "./entities/player";
 import { simulatePlayerStep } from "./systems/player-controller";
-import type { VoxelWorld } from "./world/world";
+import type { WorldQuery } from "./world/world-query";
 
 export interface GameState {
-  world: VoxelWorld;
+  world: WorldQuery;
   player: PlayerState;
   elapsedTime: number;
 }
 
 export function createGameState(
-  world: VoxelWorld,
+  world: WorldQuery,
   playerStartPosition: Vec3
 ): GameState {
   return {

--- a/src/game/systems/input.ts
+++ b/src/game/systems/input.ts
@@ -9,7 +9,7 @@ import {
   FIXED_TIMESTEP,
   PLAYER_MOVE_SPEED,
 } from "../rules/constants";
-import type { VoxelWorld } from "../world/world";
+import type { WorldQuery } from "../world/world-query";
 
 export function createPlayerInputFrame(
   input: Partial<PlayerInputFrame> = {}
@@ -24,7 +24,7 @@ export function createPlayerInputFrame(
 
 export function createAutoplayInputFrame(
   player: PlayerState,
-  world: VoxelWorld
+  world: WorldQuery
 ): PlayerInputFrame {
   const direction =
     player.position.z <= AUTOPLAY_MIN_Z + 0.25
@@ -52,7 +52,7 @@ export function createAutoplayInputFrame(
 
 function shouldAutoplayJump(
   player: PlayerState,
-  world: VoxelWorld,
+  world: WorldQuery,
   input: PlayerInputFrame
 ): boolean {
   if (!player.grounded) {

--- a/src/game/systems/player-controller.ts
+++ b/src/game/systems/player-controller.ts
@@ -12,7 +12,7 @@ import {
   PLAYER_JUMP_VELOCITY,
   PLAYER_MOVE_SPEED,
 } from "../rules/constants";
-import type { VoxelWorld } from "../world/world";
+import type { WorldQuery } from "../world/world-query";
 
 type Axis = "x" | "y" | "z";
 
@@ -22,7 +22,7 @@ interface AxisResolution {
 }
 
 function resolveAxis(
-  world: VoxelWorld,
+  world: WorldQuery,
   aabb: ReturnType<typeof createBodyAABB>,
   axis: Axis,
   amount: number
@@ -113,7 +113,7 @@ function createMoveResult(previousGrounded: boolean): MoveResult {
 export function simulatePlayerStep(
   player: PlayerState,
   input: PlayerInputFrame,
-  world: VoxelWorld,
+  world: WorldQuery,
   dt: number
 ): PlayerState {
   const moveResult = createMoveResult(player.grounded);

--- a/src/game/world/procedural/chunk-coords.ts
+++ b/src/game/world/procedural/chunk-coords.ts
@@ -1,0 +1,31 @@
+export const CHUNK_SIZE_XZ = 16;
+export const WORLD_MIN_Y = 0;
+export const WORLD_MAX_Y = 32;
+
+export interface ChunkCoord {
+  chunkX: number;
+  chunkZ: number;
+}
+
+export function floorDiv(value: number, size: number): number {
+  return Math.floor(value / size);
+}
+
+export function worldToChunkCoord(x: number, z: number): ChunkCoord {
+  return {
+    chunkX: floorDiv(x, CHUNK_SIZE_XZ),
+    chunkZ: floorDiv(z, CHUNK_SIZE_XZ),
+  };
+}
+
+export function localCoord(value: number): number {
+  return ((value % CHUNK_SIZE_XZ) + CHUNK_SIZE_XZ) % CHUNK_SIZE_XZ;
+}
+
+export function chunkKey(chunkX: number, chunkZ: number): string {
+  return `${chunkX},${chunkZ}`;
+}
+
+export function chunkOrigin(chunkX: number, chunkZ: number): [number, number] {
+  return [chunkX * CHUNK_SIZE_XZ, chunkZ * CHUNK_SIZE_XZ];
+}

--- a/src/game/world/procedural/chunk-store.ts
+++ b/src/game/world/procedural/chunk-store.ts
@@ -1,0 +1,120 @@
+import type { VoxelChunk } from "./chunk";
+import { chunkKey } from "./chunk-coords";
+import { TerrainGenerator } from "./terrain-generator";
+
+export interface ChunkStoreOptions {
+  generator?: TerrainGenerator;
+  maxCachedChunks?: number;
+}
+
+export class ChunkStore {
+  private readonly generator: TerrainGenerator;
+  private readonly chunks = new Map<string, VoxelChunk>();
+  private maxCachedChunks: number;
+  private accessClock = 0;
+
+  constructor(options: ChunkStoreOptions = {}) {
+    this.generator = options.generator ?? new TerrainGenerator();
+    this.maxCachedChunks = options.maxCachedChunks ?? 81;
+  }
+
+  public setMaxCachedChunks(maxCachedChunks: number): void {
+    this.maxCachedChunks = maxCachedChunks;
+    this.evictStaleChunks();
+  }
+
+  public get size(): number {
+    return this.chunks.size;
+  }
+
+  public getLoadedChunks(): VoxelChunk[] {
+    return Array.from(this.chunks.values());
+  }
+
+  public hasChunk(chunkX: number, chunkZ: number): boolean {
+    return this.chunks.has(chunkKey(chunkX, chunkZ));
+  }
+
+  public getChunk(chunkX: number, chunkZ: number): VoxelChunk | null {
+    const chunk = this.chunks.get(chunkKey(chunkX, chunkZ));
+    if (!chunk) {
+      return null;
+    }
+
+    this.touch(chunk);
+    return chunk;
+  }
+
+  public ensureChunk(chunkX: number, chunkZ: number): VoxelChunk {
+    const key = chunkKey(chunkX, chunkZ);
+    const existing = this.chunks.get(key);
+    if (existing) {
+      this.touch(existing);
+      return existing;
+    }
+
+    const chunk = this.generator.generateChunk(chunkX, chunkZ);
+    this.touch(chunk);
+    this.chunks.set(key, chunk);
+    this.evictStaleChunks();
+    return chunk;
+  }
+
+  public ensureWindow(
+    centerChunkX: number,
+    centerChunkZ: number,
+    radius: number
+  ): VoxelChunk[] {
+    const chunks: VoxelChunk[] = [];
+    for (
+      let chunkZ = centerChunkZ - radius;
+      chunkZ <= centerChunkZ + radius;
+      chunkZ++
+    ) {
+      for (
+        let chunkX = centerChunkX - radius;
+        chunkX <= centerChunkX + radius;
+        chunkX++
+      ) {
+        chunks.push(this.ensureChunk(chunkX, chunkZ));
+      }
+    }
+
+    return chunks;
+  }
+
+  public retainWindow(
+    centerChunkX: number,
+    centerChunkZ: number,
+    radius: number
+  ): void {
+    for (const [key, chunk] of Array.from(this.chunks.entries())) {
+      const distance = Math.max(
+        Math.abs(chunk.chunkX - centerChunkX),
+        Math.abs(chunk.chunkZ - centerChunkZ)
+      );
+      if (distance > radius) {
+        this.chunks.delete(key);
+      }
+    }
+  }
+
+  private touch(chunk: VoxelChunk): void {
+    this.accessClock += 1;
+    chunk.lastAccessedAt = this.accessClock;
+  }
+
+  private evictStaleChunks(): void {
+    if (this.chunks.size <= this.maxCachedChunks) {
+      return;
+    }
+
+    const chunksByAccess = Array.from(this.chunks.values()).sort(
+      (a, b) => a.lastAccessedAt - b.lastAccessedAt
+    );
+    const evictCount = this.chunks.size - this.maxCachedChunks;
+    for (const chunk of chunksByAccess.slice(0, evictCount)) {
+      this.chunks.delete(chunkKey(chunk.chunkX, chunk.chunkZ));
+    }
+  }
+}

--- a/src/game/world/procedural/chunk.ts
+++ b/src/game/world/procedural/chunk.ts
@@ -1,0 +1,37 @@
+import type { LoadedWorldCell } from "../world-loader";
+import { CHUNK_SIZE_XZ, WORLD_MAX_Y, WORLD_MIN_Y } from "./chunk-coords";
+
+export type BiomeId = "grassland" | "beach" | "shallows" | "rocky";
+
+export interface GeneratedColumn {
+  height: number;
+  biome: BiomeId;
+  surfaceBlockId: number;
+  subsurfaceBlockId: number;
+  fluidLevel: number | null;
+}
+
+export interface VoxelChunk {
+  chunkX: number;
+  chunkZ: number;
+  minY: number;
+  maxY: number;
+  cells: LoadedWorldCell[];
+  exposedCells: LoadedWorldCell[];
+  heightmap: Int16Array;
+  biomes: BiomeId[];
+  generatedAt: number;
+  lastAccessedAt: number;
+}
+
+export function columnIndex(localX: number, localZ: number): number {
+  return localZ * CHUNK_SIZE_XZ + localX;
+}
+
+export function createEmptyHeightmap(): Int16Array {
+  return new Int16Array(CHUNK_SIZE_XZ * CHUNK_SIZE_XZ).fill(WORLD_MIN_Y);
+}
+
+export function clampWorldY(y: number): number {
+  return Math.max(WORLD_MIN_Y, Math.min(WORLD_MAX_Y, y));
+}

--- a/src/game/world/procedural/lod-policy.ts
+++ b/src/game/world/procedural/lod-policy.ts
@@ -1,4 +1,5 @@
 export type ChunkLod = "high" | "mid" | "wire" | "horizon" | "unloaded";
+export const FULL_DETAIL_SIZE_XZ = 10;
 export type ProceduralRuntimeMode = "preview" | "interactive";
 
 export interface LodBudget {

--- a/src/game/world/procedural/lod-policy.ts
+++ b/src/game/world/procedural/lod-policy.ts
@@ -1,0 +1,72 @@
+export type ChunkLod = "high" | "mid" | "wire" | "horizon" | "unloaded";
+export type ProceduralRuntimeMode = "preview" | "interactive";
+
+export interface LodBudget {
+  highDetailRadius: number;
+  midDetailRadius: number;
+  wireRadius: number;
+  horizonRadius: number;
+  collisionRadius: number;
+  maxCachedChunks: number;
+  particlesEnabled: boolean;
+  shadowsEnabled: boolean;
+}
+
+export const PROCEDURAL_LOD_BUDGETS: Record<ProceduralRuntimeMode, LodBudget> =
+  {
+    preview: {
+      highDetailRadius: 0,
+      midDetailRadius: 1,
+      wireRadius: 2,
+      horizonRadius: 3,
+      collisionRadius: 0,
+      maxCachedChunks: 25,
+      particlesEnabled: false,
+      shadowsEnabled: false,
+    },
+    interactive: {
+      highDetailRadius: 1,
+      midDetailRadius: 2,
+      wireRadius: 3,
+      horizonRadius: 4,
+      collisionRadius: 2,
+      maxCachedChunks: 81,
+      particlesEnabled: true,
+      shadowsEnabled: true,
+    },
+  };
+
+export function classifyChunkLod(
+  distanceChunks: number,
+  budget: LodBudget
+): ChunkLod {
+  if (distanceChunks <= budget.highDetailRadius) {
+    return "high";
+  }
+
+  if (distanceChunks <= budget.midDetailRadius) {
+    return "mid";
+  }
+
+  if (distanceChunks <= budget.wireRadius) {
+    return "wire";
+  }
+
+  if (distanceChunks <= budget.horizonRadius) {
+    return "horizon";
+  }
+
+  return "unloaded";
+}
+
+export function chunkChebyshevDistance(
+  chunkX: number,
+  chunkZ: number,
+  centerChunkX: number,
+  centerChunkZ: number
+): number {
+  return Math.max(
+    Math.abs(chunkX - centerChunkX),
+    Math.abs(chunkZ - centerChunkZ)
+  );
+}

--- a/src/game/world/procedural/procedural-world.test.ts
+++ b/src/game/world/procedural/procedural-world.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
+import worldData from "../../../components/world/world-data";
 import { createBodyAABB } from "../../core/math/aabb";
 import { vec3 } from "../../core/math/vec3";
 import { PLAYER_COLLIDER } from "../../rules/constants";
+import { loadWorldCellsFromString } from "../world-loader";
 import { columnIndex } from "./chunk";
 import { CHUNK_SIZE_XZ } from "./chunk-coords";
 import { ChunkStore } from "./chunk-store";
@@ -89,6 +91,41 @@ describe("ProceduralVoxelWorld", () => {
           cell.z <= bounds.max.z
       )
     ).toBe(true);
+  });
+
+  it("keeps preview bounds anchored even as focus updates", () => {
+    const world = new ProceduralVoxelWorld({
+      seed: 17,
+      mode: "preview",
+      centerX: 5,
+      centerZ: 5,
+    });
+    const initialBounds = world.getBounds();
+
+    world.updateFocus(100, 100, "preview");
+
+    expect(world.getBounds()).toEqual(initialBounds);
+  });
+
+  it("uses the existing static map as the initial 10x10 seed area", () => {
+    const seedCells = loadWorldCellsFromString(worldData);
+    const world = new ProceduralVoxelWorld({
+      seed: 17,
+      mode: "preview",
+      centerX: 5,
+      centerZ: 5,
+      seedCells,
+    });
+    const bounds = world.getBounds();
+
+    expect(bounds.min.x).toBe(0);
+    expect(bounds.min.z).toBe(0);
+    expect(bounds.max.x).toBe(9);
+    expect(bounds.max.z).toBe(9);
+
+    for (const cell of seedCells) {
+      expect(world.getBlockIdAtCell(cell.x, cell.y, cell.z)).toBe(cell.id);
+    }
   });
 
   it("places spawn above generated terrain", () => {

--- a/src/game/world/procedural/procedural-world.test.ts
+++ b/src/game/world/procedural/procedural-world.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "bun:test";
+import { createBodyAABB } from "../../core/math/aabb";
+import { vec3 } from "../../core/math/vec3";
+import { PLAYER_COLLIDER } from "../../rules/constants";
+import { columnIndex } from "./chunk";
+import { CHUNK_SIZE_XZ } from "./chunk-coords";
+import { ChunkStore } from "./chunk-store";
+import { classifyChunkLod, PROCEDURAL_LOD_BUDGETS } from "./lod-policy";
+import { ProceduralVoxelWorld } from "./procedural-world";
+import { TerrainGenerator } from "./terrain-generator";
+
+describe("TerrainGenerator", () => {
+  it("generates deterministic chunks for a seed", () => {
+    const first = new TerrainGenerator({ seed: 42 }).generateChunk(1, -2);
+    const second = new TerrainGenerator({ seed: 42 }).generateChunk(1, -2);
+
+    expect(Array.from(first.heightmap)).toEqual(Array.from(second.heightmap));
+    expect(first.exposedCells).toEqual(second.exposedCells);
+  });
+
+  it("keeps heights continuous across chunk boundaries", () => {
+    const generator = new TerrainGenerator({ seed: 7 });
+    const left = generator.generateChunk(0, 0);
+    const right = generator.generateChunk(1, 0);
+
+    for (let z = 0; z < CHUNK_SIZE_XZ; z++) {
+      const leftBoundary = left.heightmap[columnIndex(CHUNK_SIZE_XZ - 1, z)];
+      const rightBoundary = right.heightmap[columnIndex(0, z)];
+      expect(Math.abs(leftBoundary - rightBoundary)).toBeLessThanOrEqual(4);
+    }
+  });
+});
+
+describe("ChunkStore", () => {
+  it("evicts least-recently-used chunks when over budget", () => {
+    const store = new ChunkStore({
+      generator: new TerrainGenerator({ seed: 1 }),
+      maxCachedChunks: 2,
+    });
+
+    store.ensureChunk(0, 0);
+    store.ensureChunk(1, 0);
+    store.ensureChunk(2, 0);
+
+    expect(store.size).toBe(2);
+    expect(store.hasChunk(0, 0)).toBe(false);
+    expect(store.hasChunk(1, 0)).toBe(true);
+    expect(store.hasChunk(2, 0)).toBe(true);
+  });
+});
+
+describe("ProceduralVoxelWorld", () => {
+  it("answers block and collision queries across chunk boundaries", () => {
+    const world = new ProceduralVoxelWorld({ seed: 5, mode: "interactive" });
+    const leftHeight = world.getHighestSolidCell(CHUNK_SIZE_XZ - 1, 0);
+    const rightHeight = world.getHighestSolidCell(CHUNK_SIZE_XZ, 0);
+
+    expect(leftHeight).not.toBeNull();
+    expect(rightHeight).not.toBeNull();
+    expect(world.isCellSolid(CHUNK_SIZE_XZ - 1, leftHeight as number, 0)).toBe(
+      true
+    );
+    expect(world.isCellSolid(CHUNK_SIZE_XZ, rightHeight as number, 0)).toBe(
+      true
+    );
+  });
+
+  it("places spawn above generated terrain", () => {
+    const world = new ProceduralVoxelWorld({ seed: 11 });
+    const spawn = world.findSpawnColumn(0, 0);
+
+    expect(world.isCellSolid(spawn.x, spawn.y - 1, spawn.z)).toBe(true);
+    expect(world.isCellSolid(spawn.x, spawn.y, spawn.z)).toBe(false);
+  });
+
+  it("collides with generated ground", () => {
+    const world = new ProceduralVoxelWorld({ seed: 13, mode: "interactive" });
+    const spawn = world.findSpawnColumn(0, 0);
+    const aabb = createBodyAABB(
+      vec3(spawn.x + 0.5, spawn.y - 0.9, spawn.z + 0.5),
+      PLAYER_COLLIDER
+    );
+
+    expect(world.collidesAABB(aabb)).toBe(true);
+  });
+});
+
+describe("procedural LOD policy", () => {
+  it("keeps preview mode lightweight", () => {
+    const budget = PROCEDURAL_LOD_BUDGETS.preview;
+
+    expect(classifyChunkLod(0, budget)).toBe("high");
+    expect(classifyChunkLod(1, budget)).toBe("mid");
+    expect(classifyChunkLod(2, budget)).toBe("wire");
+    expect(classifyChunkLod(4, budget)).toBe("unloaded");
+    expect(budget.particlesEnabled).toBe(false);
+    expect(budget.shadowsEnabled).toBe(false);
+  });
+});

--- a/src/game/world/procedural/procedural-world.test.ts
+++ b/src/game/world/procedural/procedural-world.test.ts
@@ -3,6 +3,7 @@ import worldData from "../../../components/world/world-data";
 import { createBodyAABB } from "../../core/math/aabb";
 import { vec3 } from "../../core/math/vec3";
 import { PLAYER_COLLIDER } from "../../rules/constants";
+import { VoxelWorld } from "../world";
 import { loadWorldCellsFromString } from "../world-loader";
 import { columnIndex } from "./chunk";
 import { CHUNK_SIZE_XZ } from "./chunk-coords";
@@ -126,6 +127,30 @@ describe("ProceduralVoxelWorld", () => {
     for (const cell of seedCells) {
       expect(world.getBlockIdAtCell(cell.x, cell.y, cell.z)).toBe(cell.id);
     }
+  });
+
+  it("matches the static map exposed cells for the seeded 10x10 preview", () => {
+    const seedCells = loadWorldCellsFromString(worldData);
+    const staticWorld = new VoxelWorld(seedCells);
+    const proceduralWorld = new ProceduralVoxelWorld({
+      seed: 17,
+      mode: "preview",
+      centerX: 5,
+      centerZ: 5,
+      seedCells,
+    });
+    const staticKeys = new Set(
+      staticWorld
+        .getExposedRenderableCells()
+        .map((cell) => `${cell.x},${cell.y},${cell.z},${cell.id}`)
+    );
+    const proceduralKeys = new Set(
+      proceduralWorld
+        .getExposedRenderableCells()
+        .map((cell) => `${cell.x},${cell.y},${cell.z},${cell.id}`)
+    );
+
+    expect(proceduralKeys).toEqual(staticKeys);
   });
 
   it("places spawn above generated terrain", () => {

--- a/src/game/world/procedural/procedural-world.test.ts
+++ b/src/game/world/procedural/procedural-world.test.ts
@@ -5,7 +5,11 @@ import { PLAYER_COLLIDER } from "../../rules/constants";
 import { columnIndex } from "./chunk";
 import { CHUNK_SIZE_XZ } from "./chunk-coords";
 import { ChunkStore } from "./chunk-store";
-import { classifyChunkLod, PROCEDURAL_LOD_BUDGETS } from "./lod-policy";
+import {
+  classifyChunkLod,
+  FULL_DETAIL_SIZE_XZ,
+  PROCEDURAL_LOD_BUDGETS,
+} from "./lod-policy";
 import { ProceduralVoxelWorld } from "./procedural-world";
 import { TerrainGenerator } from "./terrain-generator";
 
@@ -63,6 +67,28 @@ describe("ProceduralVoxelWorld", () => {
     expect(world.isCellSolid(CHUNK_SIZE_XZ, rightHeight as number, 0)).toBe(
       true
     );
+  });
+
+  it("keeps the fully rendered procedural footprint at 10x10 columns", () => {
+    const world = new ProceduralVoxelWorld({ seed: 17, mode: "interactive" });
+    const bounds = world.getBounds();
+    const cells = world.getRenderableCells();
+    const renderedColumns = new Set(cells.map((cell) => `${cell.x},${cell.z}`));
+
+    expect(bounds.max.x - bounds.min.x + 1).toBe(FULL_DETAIL_SIZE_XZ);
+    expect(bounds.max.z - bounds.min.z + 1).toBe(FULL_DETAIL_SIZE_XZ);
+    expect(renderedColumns.size).toBe(
+      FULL_DETAIL_SIZE_XZ * FULL_DETAIL_SIZE_XZ
+    );
+    expect(
+      cells.every(
+        (cell) =>
+          cell.x >= bounds.min.x &&
+          cell.x <= bounds.max.x &&
+          cell.z >= bounds.min.z &&
+          cell.z <= bounds.max.z
+      )
+    ).toBe(true);
   });
 
   it("places spawn above generated terrain", () => {

--- a/src/game/world/procedural/procedural-world.ts
+++ b/src/game/world/procedural/procedural-world.ts
@@ -1,0 +1,291 @@
+import type { AABB } from "../../core/math/aabb";
+import type { CellCoord, CollisionKind, WorldBounds } from "../../core/types";
+import { COLLISION_EPSILON } from "../../rules/constants";
+import {
+  type BlockDefinition,
+  getBlockDefinition,
+  isBlockFluid,
+  isBlockSolid,
+} from "../block-registry";
+import type { FluidAdjacency } from "../world";
+import type { LoadedWorldCell } from "../world-loader";
+import type { RenderableWorldQuery } from "../world-query";
+import { columnIndex } from "./chunk";
+import {
+  CHUNK_SIZE_XZ,
+  chunkOrigin,
+  WORLD_MIN_Y,
+  worldToChunkCoord,
+} from "./chunk-coords";
+import { ChunkStore } from "./chunk-store";
+import {
+  chunkChebyshevDistance,
+  type LodBudget,
+  PROCEDURAL_LOD_BUDGETS,
+  type ProceduralRuntimeMode,
+} from "./lod-policy";
+import { TerrainGenerator } from "./terrain-generator";
+
+const AIR = 0;
+const STONE = 1;
+const WATER = 9;
+
+export interface ProceduralVoxelWorldOptions {
+  seed?: number;
+  mode?: ProceduralRuntimeMode;
+  centerX?: number;
+  centerZ?: number;
+}
+
+export interface SpawnColumn {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export class ProceduralVoxelWorld implements RenderableWorldQuery {
+  private readonly generator: TerrainGenerator;
+  private readonly store: ChunkStore;
+  private mode: ProceduralRuntimeMode;
+  private centerChunkX = 0;
+  private centerChunkZ = 0;
+
+  constructor(options: ProceduralVoxelWorldOptions = {}) {
+    this.mode = options.mode ?? "preview";
+    this.generator = new TerrainGenerator({ seed: options.seed });
+    this.store = new ChunkStore({
+      generator: this.generator,
+      maxCachedChunks: this.budget.maxCachedChunks,
+    });
+    this.updateFocus(options.centerX ?? 0, options.centerZ ?? 0, this.mode);
+  }
+
+  public get budget(): LodBudget {
+    return PROCEDURAL_LOD_BUDGETS[this.mode];
+  }
+
+  public updateFocus(
+    x: number,
+    z: number,
+    mode: ProceduralRuntimeMode = this.mode
+  ): boolean {
+    const previousMode = this.mode;
+    const previousChunkX = this.centerChunkX;
+    const previousChunkZ = this.centerChunkZ;
+
+    this.mode = mode;
+    this.store.setMaxCachedChunks(this.budget.maxCachedChunks);
+
+    const { chunkX, chunkZ } = worldToChunkCoord(Math.floor(x), Math.floor(z));
+    this.centerChunkX = chunkX;
+    this.centerChunkZ = chunkZ;
+    const residentRenderRadius = Math.max(
+      this.budget.highDetailRadius,
+      this.budget.midDetailRadius
+    );
+    this.store.ensureWindow(chunkX, chunkZ, residentRenderRadius);
+    this.store.retainWindow(chunkX, chunkZ, residentRenderRadius);
+
+    return (
+      previousMode !== mode ||
+      previousChunkX !== chunkX ||
+      previousChunkZ !== chunkZ
+    );
+  }
+
+  public findSpawnColumn(x = 0, z = 0): SpawnColumn {
+    const height = this.getHighestSolidCell(x, z) ?? WORLD_MIN_Y;
+    return { x, y: height + 1, z };
+  }
+
+  public getBounds(): WorldBounds {
+    const chunks = this.store.getLoadedChunks();
+    if (chunks.length === 0) {
+      return {
+        min: { x: 0, y: WORLD_MIN_Y, z: 0 },
+        max: { x: 0, y: WORLD_MIN_Y, z: 0 },
+      };
+    }
+
+    let minX = Number.POSITIVE_INFINITY;
+    let minZ = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let maxY = WORLD_MIN_Y;
+    let maxZ = Number.NEGATIVE_INFINITY;
+
+    for (const chunk of chunks) {
+      const [originX, originZ] = chunkOrigin(chunk.chunkX, chunk.chunkZ);
+      minX = Math.min(minX, originX);
+      minZ = Math.min(minZ, originZ);
+      maxX = Math.max(maxX, originX + CHUNK_SIZE_XZ - 1);
+      maxY = Math.max(maxY, chunk.maxY);
+      maxZ = Math.max(maxZ, originZ + CHUNK_SIZE_XZ - 1);
+    }
+
+    return {
+      min: { x: minX, y: WORLD_MIN_Y, z: minZ },
+      max: { x: maxX, y: maxY, z: maxZ },
+    };
+  }
+
+  public getRenderableCells(): LoadedWorldCell[] {
+    return this.getCellsForActiveWindow("full");
+  }
+
+  public getExposedRenderableCells(): LoadedWorldCell[] {
+    return this.getCellsForActiveWindow("preview");
+  }
+
+  public getBlockIdAtCell(x: number, y: number, z: number): number {
+    if (y < WORLD_MIN_Y) {
+      return STONE;
+    }
+
+    const column = this.generator.getColumn(x, z);
+    if (y <= column.height) {
+      if (y === column.height) {
+        return column.surfaceBlockId;
+      }
+
+      return y >= column.height - 3 ? column.subsurfaceBlockId : STONE;
+    }
+
+    if (column.fluidLevel !== null && y <= column.fluidLevel) {
+      return WATER;
+    }
+
+    return AIR;
+  }
+
+  public getBlockAtCell(x: number, y: number, z: number): BlockDefinition {
+    return getBlockDefinition(this.getBlockIdAtCell(x, y, z));
+  }
+
+  public getCollisionKind(x: number, y: number, z: number): CollisionKind {
+    return this.getBlockAtCell(x, y, z).collisionKind;
+  }
+
+  public isCellSolid(x: number, y: number, z: number): boolean {
+    return isBlockSolid(this.getBlockIdAtCell(x, y, z));
+  }
+
+  public isCellFluid(x: number, y: number, z: number): boolean {
+    return isBlockFluid(this.getBlockIdAtCell(x, y, z));
+  }
+
+  public getFluidAdjacency(x: number, y: number, z: number): FluidAdjacency {
+    return {
+      top: this.isCellFluid(x, y + 1, z),
+      bottom: this.isCellFluid(x, y - 1, z),
+      north: this.isCellFluid(x, y, z - 1),
+      south: this.isCellFluid(x, y, z + 1),
+      east: this.isCellFluid(x + 1, y, z),
+      west: this.isCellFluid(x - 1, y, z),
+    };
+  }
+
+  public getHighestSolidCell(x: number, z: number): number | null {
+    return this.generator.getColumn(x, z).height;
+  }
+
+  public getOverlappingCells(aabb: AABB): CellCoord[] {
+    const minX = Math.floor(aabb.min.x + COLLISION_EPSILON);
+    const maxX = Math.floor(aabb.max.x - COLLISION_EPSILON);
+    const minY = Math.floor(aabb.min.y + COLLISION_EPSILON);
+    const maxY = Math.floor(aabb.max.y - COLLISION_EPSILON);
+    const minZ = Math.floor(aabb.min.z + COLLISION_EPSILON);
+    const maxZ = Math.floor(aabb.max.z - COLLISION_EPSILON);
+
+    const cells: CellCoord[] = [];
+    for (let x = minX; x <= maxX; x++) {
+      for (let y = minY; y <= maxY; y++) {
+        for (let z = minZ; z <= maxZ; z++) {
+          cells.push({ x, y, z });
+        }
+      }
+    }
+
+    return cells;
+  }
+
+  public collidesAABB(aabb: AABB): boolean {
+    if (aabb.min.y < WORLD_MIN_Y) {
+      return true;
+    }
+
+    this.ensureCollisionChunks(aabb);
+
+    for (const cell of this.getOverlappingCells(aabb)) {
+      if (this.isCellSolid(cell.x, cell.y, cell.z)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private getCellsForActiveWindow(
+    detail: "full" | "preview"
+  ): LoadedWorldCell[] {
+    const cells: LoadedWorldCell[] = [];
+    for (const chunk of this.store.getLoadedChunks()) {
+      const distance = chunkChebyshevDistance(
+        chunk.chunkX,
+        chunk.chunkZ,
+        this.centerChunkX,
+        this.centerChunkZ
+      );
+
+      if (distance <= this.budget.highDetailRadius) {
+        cells.push(...chunk.exposedCells);
+        continue;
+      }
+
+      if (detail === "preview" && distance <= this.budget.midDetailRadius) {
+        cells.push(
+          ...this.getHeightmapSurfaceCells(chunk.chunkX, chunk.chunkZ)
+        );
+      }
+    }
+
+    return cells;
+  }
+
+  private getHeightmapSurfaceCells(
+    chunkX: number,
+    chunkZ: number
+  ): LoadedWorldCell[] {
+    const chunk = this.store.ensureChunk(chunkX, chunkZ);
+    const [originX, originZ] = chunkOrigin(chunkX, chunkZ);
+    const cells: LoadedWorldCell[] = [];
+
+    for (let localZ = 0; localZ < CHUNK_SIZE_XZ; localZ++) {
+      for (let localX = 0; localX < CHUNK_SIZE_XZ; localX++) {
+        const index = columnIndex(localX, localZ);
+        const x = originX + localX;
+        const z = originZ + localZ;
+        const y = chunk.heightmap[index];
+        cells.push({ x, y, z, id: this.getBlockIdAtCell(x, y, z) });
+      }
+    }
+
+    return cells;
+  }
+
+  private ensureCollisionChunks(aabb: AABB): void {
+    const min = worldToChunkCoord(
+      Math.floor(aabb.min.x),
+      Math.floor(aabb.min.z)
+    );
+    const max = worldToChunkCoord(
+      Math.floor(aabb.max.x),
+      Math.floor(aabb.max.z)
+    );
+
+    for (let chunkZ = min.chunkZ; chunkZ <= max.chunkZ; chunkZ++) {
+      for (let chunkX = min.chunkX; chunkX <= max.chunkX; chunkX++) {
+        this.store.ensureChunk(chunkX, chunkZ);
+      }
+    }
+  }
+}

--- a/src/game/world/procedural/procedural-world.ts
+++ b/src/game/world/procedural/procedural-world.ts
@@ -10,16 +10,10 @@ import {
 import type { FluidAdjacency } from "../world";
 import type { LoadedWorldCell } from "../world-loader";
 import type { RenderableWorldQuery } from "../world-query";
-import { columnIndex } from "./chunk";
-import {
-  CHUNK_SIZE_XZ,
-  chunkOrigin,
-  WORLD_MIN_Y,
-  worldToChunkCoord,
-} from "./chunk-coords";
+import { WORLD_MIN_Y, worldToChunkCoord } from "./chunk-coords";
 import { ChunkStore } from "./chunk-store";
 import {
-  chunkChebyshevDistance,
+  FULL_DETAIL_SIZE_XZ,
   type LodBudget,
   PROCEDURAL_LOD_BUDGETS,
   type ProceduralRuntimeMode,
@@ -49,6 +43,8 @@ export class ProceduralVoxelWorld implements RenderableWorldQuery {
   private mode: ProceduralRuntimeMode;
   private centerChunkX = 0;
   private centerChunkZ = 0;
+  private focusCellX = 0;
+  private focusCellZ = 0;
 
   constructor(options: ProceduralVoxelWorldOptions = {}) {
     this.mode = options.mode ?? "preview";
@@ -72,11 +68,18 @@ export class ProceduralVoxelWorld implements RenderableWorldQuery {
     const previousMode = this.mode;
     const previousChunkX = this.centerChunkX;
     const previousChunkZ = this.centerChunkZ;
+    const previousFocusCellX = this.focusCellX;
+    const previousFocusCellZ = this.focusCellZ;
 
     this.mode = mode;
     this.store.setMaxCachedChunks(this.budget.maxCachedChunks);
 
-    const { chunkX, chunkZ } = worldToChunkCoord(Math.floor(x), Math.floor(z));
+    this.focusCellX = Math.floor(x);
+    this.focusCellZ = Math.floor(z);
+    const { chunkX, chunkZ } = worldToChunkCoord(
+      this.focusCellX,
+      this.focusCellZ
+    );
     this.centerChunkX = chunkX;
     this.centerChunkZ = chunkZ;
     const residentRenderRadius = Math.max(
@@ -89,7 +92,9 @@ export class ProceduralVoxelWorld implements RenderableWorldQuery {
     return (
       previousMode !== mode ||
       previousChunkX !== chunkX ||
-      previousChunkZ !== chunkZ
+      previousChunkZ !== chunkZ ||
+      previousFocusCellX !== this.focusCellX ||
+      previousFocusCellZ !== this.focusCellZ
     );
   }
 
@@ -99,27 +104,22 @@ export class ProceduralVoxelWorld implements RenderableWorldQuery {
   }
 
   public getBounds(): WorldBounds {
-    const chunks = this.store.getLoadedChunks();
-    if (chunks.length === 0) {
-      return {
-        min: { x: 0, y: WORLD_MIN_Y, z: 0 },
-        max: { x: 0, y: WORLD_MIN_Y, z: 0 },
-      };
-    }
+    return this.getFullDetailBounds();
+  }
 
-    let minX = Number.POSITIVE_INFINITY;
-    let minZ = Number.POSITIVE_INFINITY;
-    let maxX = Number.NEGATIVE_INFINITY;
+  public getFullDetailBounds(): WorldBounds {
+    const halfSize = Math.floor(FULL_DETAIL_SIZE_XZ / 2);
+    const minX = this.focusCellX - halfSize;
+    const minZ = this.focusCellZ - halfSize;
+    const maxX = minX + FULL_DETAIL_SIZE_XZ - 1;
+    const maxZ = minZ + FULL_DETAIL_SIZE_XZ - 1;
     let maxY = WORLD_MIN_Y;
-    let maxZ = Number.NEGATIVE_INFINITY;
 
-    for (const chunk of chunks) {
-      const [originX, originZ] = chunkOrigin(chunk.chunkX, chunk.chunkZ);
-      minX = Math.min(minX, originX);
-      minZ = Math.min(minZ, originZ);
-      maxX = Math.max(maxX, originX + CHUNK_SIZE_XZ - 1);
-      maxY = Math.max(maxY, chunk.maxY);
-      maxZ = Math.max(maxZ, originZ + CHUNK_SIZE_XZ - 1);
+    for (let z = minZ; z <= maxZ; z++) {
+      for (let x = minX; x <= maxX; x++) {
+        const column = this.generator.getColumn(x, z);
+        maxY = Math.max(maxY, column.fluidLevel ?? column.height);
+      }
     }
 
     return {
@@ -227,49 +227,32 @@ export class ProceduralVoxelWorld implements RenderableWorldQuery {
   private getCellsForActiveWindow(
     detail: "full" | "preview"
   ): LoadedWorldCell[] {
+    const bounds = this.getFullDetailBounds();
     const cells: LoadedWorldCell[] = [];
+
     for (const chunk of this.store.getLoadedChunks()) {
-      const distance = chunkChebyshevDistance(
-        chunk.chunkX,
-        chunk.chunkZ,
-        this.centerChunkX,
-        this.centerChunkZ
-      );
-
-      if (distance <= this.budget.highDetailRadius) {
-        cells.push(...chunk.exposedCells);
-        continue;
-      }
-
-      if (detail === "preview" && distance <= this.budget.midDetailRadius) {
-        cells.push(
-          ...this.getHeightmapSurfaceCells(chunk.chunkX, chunk.chunkZ)
-        );
+      const sourceCells = detail === "full" ? chunk.cells : chunk.exposedCells;
+      for (const cell of sourceCells) {
+        if (this.isWithinFullDetailFootprint(cell.x, cell.z, bounds)) {
+          cells.push(cell);
+        }
       }
     }
 
     return cells;
   }
 
-  private getHeightmapSurfaceCells(
-    chunkX: number,
-    chunkZ: number
-  ): LoadedWorldCell[] {
-    const chunk = this.store.ensureChunk(chunkX, chunkZ);
-    const [originX, originZ] = chunkOrigin(chunkX, chunkZ);
-    const cells: LoadedWorldCell[] = [];
-
-    for (let localZ = 0; localZ < CHUNK_SIZE_XZ; localZ++) {
-      for (let localX = 0; localX < CHUNK_SIZE_XZ; localX++) {
-        const index = columnIndex(localX, localZ);
-        const x = originX + localX;
-        const z = originZ + localZ;
-        const y = chunk.heightmap[index];
-        cells.push({ x, y, z, id: this.getBlockIdAtCell(x, y, z) });
-      }
-    }
-
-    return cells;
+  private isWithinFullDetailFootprint(
+    x: number,
+    z: number,
+    bounds = this.getFullDetailBounds()
+  ): boolean {
+    return (
+      x >= bounds.min.x &&
+      x <= bounds.max.x &&
+      z >= bounds.min.z &&
+      z <= bounds.max.z
+    );
   }
 
   private ensureCollisionChunks(aabb: AABB): void {

--- a/src/game/world/procedural/procedural-world.ts
+++ b/src/game/world/procedural/procedural-world.ts
@@ -20,15 +20,14 @@ import {
 } from "./lod-policy";
 import { TerrainGenerator } from "./terrain-generator";
 
-const AIR = 0;
 const STONE = 1;
-const WATER = 9;
 
 export interface ProceduralVoxelWorldOptions {
   seed?: number;
   mode?: ProceduralRuntimeMode;
   centerX?: number;
   centerZ?: number;
+  seedCells?: LoadedWorldCell[];
 }
 
 export interface SpawnColumn {
@@ -45,10 +44,17 @@ export class ProceduralVoxelWorld implements RenderableWorldQuery {
   private centerChunkZ = 0;
   private focusCellX = 0;
   private focusCellZ = 0;
+  private readonly previewFocusCellX: number;
+  private readonly previewFocusCellZ: number;
 
   constructor(options: ProceduralVoxelWorldOptions = {}) {
     this.mode = options.mode ?? "preview";
-    this.generator = new TerrainGenerator({ seed: options.seed });
+    this.previewFocusCellX = Math.floor(options.centerX ?? 0);
+    this.previewFocusCellZ = Math.floor(options.centerZ ?? 0);
+    this.generator = new TerrainGenerator({
+      seed: options.seed,
+      seedCells: options.seedCells,
+    });
     this.store = new ChunkStore({
       generator: this.generator,
       maxCachedChunks: this.budget.maxCachedChunks,
@@ -74,8 +80,10 @@ export class ProceduralVoxelWorld implements RenderableWorldQuery {
     this.mode = mode;
     this.store.setMaxCachedChunks(this.budget.maxCachedChunks);
 
-    this.focusCellX = Math.floor(x);
-    this.focusCellZ = Math.floor(z);
+    this.focusCellX =
+      mode === "preview" ? this.previewFocusCellX : Math.floor(x);
+    this.focusCellZ =
+      mode === "preview" ? this.previewFocusCellZ : Math.floor(z);
     const { chunkX, chunkZ } = worldToChunkCoord(
       this.focusCellX,
       this.focusCellZ
@@ -141,20 +149,7 @@ export class ProceduralVoxelWorld implements RenderableWorldQuery {
       return STONE;
     }
 
-    const column = this.generator.getColumn(x, z);
-    if (y <= column.height) {
-      if (y === column.height) {
-        return column.surfaceBlockId;
-      }
-
-      return y >= column.height - 3 ? column.subsurfaceBlockId : STONE;
-    }
-
-    if (column.fluidLevel !== null && y <= column.fluidLevel) {
-      return WATER;
-    }
-
-    return AIR;
+    return this.generator.getBlockIdAtCell(x, y, z);
   }
 
   public getBlockAtCell(x: number, y: number, z: number): BlockDefinition {

--- a/src/game/world/procedural/terrain-generator.ts
+++ b/src/game/world/procedural/terrain-generator.ts
@@ -1,3 +1,4 @@
+import { isBlockSolid } from "../block-registry";
 import type { LoadedWorldCell } from "../world-loader";
 import {
   type BiomeId,
@@ -18,6 +19,7 @@ const WATER_LEVEL = 5;
 
 export interface TerrainGeneratorOptions {
   seed?: number;
+  seedCells?: LoadedWorldCell[];
 }
 
 function fract(value: number): number {
@@ -72,14 +74,59 @@ function biomeForHeight(height: number, slopeSignal: number): BiomeId {
   return "grassland";
 }
 
+function cellKey(x: number, y: number, z: number): string {
+  return `${x},${y},${z}`;
+}
+
+function columnKey(x: number, z: number): string {
+  return `${x},${z}`;
+}
+
 export class TerrainGenerator {
   private readonly seed: number;
+  private readonly seedBlockIds = new Map<string, number>();
+  private readonly seedColumns = new Map<string, LoadedWorldCell[]>();
+  private readonly seedSolidHeights = new Map<string, number>();
 
   constructor(options: TerrainGeneratorOptions = {}) {
     this.seed = options.seed ?? 1337;
+
+    for (const cell of options.seedCells ?? []) {
+      const key = columnKey(cell.x, cell.z);
+      this.seedBlockIds.set(cellKey(cell.x, cell.y, cell.z), cell.id);
+      const column = this.seedColumns.get(key) ?? [];
+      column.push(cell);
+      this.seedColumns.set(key, column);
+
+      if (isBlockSolid(cell.id)) {
+        this.seedSolidHeights.set(
+          key,
+          Math.max(this.seedSolidHeights.get(key) ?? WORLD_MIN_Y, cell.y)
+        );
+      }
+    }
+
+    for (const column of Array.from(this.seedColumns.values())) {
+      column.sort((a, b) => a.y - b.y);
+    }
   }
 
   public getColumn(x: number, z: number): GeneratedColumn {
+    const seededHeight = this.seedSolidHeights.get(columnKey(x, z));
+    if (seededHeight !== undefined) {
+      const surfaceBlockId = this.getBlockIdAtCell(x, seededHeight, z);
+      const subsurfaceBlockId =
+        this.getBlockIdAtCell(x, seededHeight - 1, z) || surfaceBlockId;
+
+      return {
+        height: seededHeight,
+        biome: surfaceBlockId === SAND ? "beach" : "grassland",
+        surfaceBlockId,
+        subsurfaceBlockId,
+        fluidLevel: null,
+      };
+    }
+
     const noise = terrainNoise(x, z, this.seed);
     const slopeSignal = valueNoise(x / 10, z / 10, this.seed + 101);
     const height = clampWorldY(Math.round(7 + noise));
@@ -114,6 +161,32 @@ export class TerrainGenerator {
     };
   }
 
+  public getBlockIdAtCell(x: number, y: number, z: number): number {
+    const seededColumn = this.seedColumns.get(columnKey(x, z));
+    if (seededColumn) {
+      return this.seedBlockIds.get(cellKey(x, y, z)) ?? 0;
+    }
+
+    const column = this.getColumn(x, z);
+    if (y < WORLD_MIN_Y) {
+      return STONE;
+    }
+
+    if (y <= column.height) {
+      if (y === column.height) {
+        return column.surfaceBlockId;
+      }
+
+      return y >= column.height - 3 ? column.subsurfaceBlockId : STONE;
+    }
+
+    if (column.fluidLevel !== null && y <= column.fluidLevel) {
+      return WATER;
+    }
+
+    return 0;
+  }
+
   public generateChunk(chunkX: number, chunkZ: number): VoxelChunk {
     const [originX, originZ] = chunkOrigin(chunkX, chunkZ);
     const cells: LoadedWorldCell[] = [];
@@ -128,6 +201,12 @@ export class TerrainGenerator {
         const index = columnIndex(localX, localZ);
         heightmap[index] = column.height;
         biomes[index] = column.biome;
+
+        const seededColumn = this.seedColumns.get(columnKey(worldX, worldZ));
+        if (seededColumn) {
+          cells.push(...seededColumn);
+          continue;
+        }
 
         for (let y = WORLD_MIN_Y; y <= column.height; y++) {
           const id =
@@ -183,12 +262,7 @@ export class TerrainGenerator {
         return false;
       }
 
-      const neighbor = this.getColumn(cell.x + dx, cell.z + dz);
-      if (neighborY <= neighbor.height) {
-        return false;
-      }
-
-      return neighbor.fluidLevel === null || neighborY > neighbor.fluidLevel;
+      return this.getBlockIdAtCell(cell.x + dx, neighborY, cell.z + dz) === 0;
     });
   }
 }

--- a/src/game/world/procedural/terrain-generator.ts
+++ b/src/game/world/procedural/terrain-generator.ts
@@ -247,6 +247,7 @@ export class TerrainGenerator {
   }
 
   private hasExposedFace(cell: LoadedWorldCell): boolean {
+    const isSeededCell = this.seedColumns.has(columnKey(cell.x, cell.z));
     const neighborOffsets = [
       [1, 0, 0],
       [-1, 0, 0],
@@ -257,12 +258,19 @@ export class TerrainGenerator {
     ] as const;
 
     return neighborOffsets.some(([dx, dy, dz]) => {
+      const neighborX = cell.x + dx;
       const neighborY = cell.y + dy;
+      const neighborZ = cell.z + dz;
+
+      if (isSeededCell) {
+        return !this.seedBlockIds.has(cellKey(neighborX, neighborY, neighborZ));
+      }
+
       if (neighborY < WORLD_MIN_Y) {
         return false;
       }
 
-      return this.getBlockIdAtCell(cell.x + dx, neighborY, cell.z + dz) === 0;
+      return this.getBlockIdAtCell(neighborX, neighborY, neighborZ) === 0;
     });
   }
 }

--- a/src/game/world/procedural/terrain-generator.ts
+++ b/src/game/world/procedural/terrain-generator.ts
@@ -1,0 +1,194 @@
+import type { LoadedWorldCell } from "../world-loader";
+import {
+  type BiomeId,
+  clampWorldY,
+  columnIndex,
+  createEmptyHeightmap,
+  type GeneratedColumn,
+  type VoxelChunk,
+} from "./chunk";
+import { CHUNK_SIZE_XZ, chunkOrigin, WORLD_MIN_Y } from "./chunk-coords";
+
+const STONE = 1;
+const GRASS = 2;
+const DIRT = 3;
+const WATER = 9;
+const SAND = 12;
+const WATER_LEVEL = 5;
+
+export interface TerrainGeneratorOptions {
+  seed?: number;
+}
+
+function fract(value: number): number {
+  return value - Math.floor(value);
+}
+
+function hash2d(x: number, z: number, seed: number): number {
+  const n = Math.sin(x * 127.1 + z * 311.7 + seed * 74.7) * 43758.5453;
+  return fract(n);
+}
+
+function smoothstep(value: number): number {
+  return value * value * (3 - 2 * value);
+}
+
+function valueNoise(x: number, z: number, seed: number): number {
+  const x0 = Math.floor(x);
+  const z0 = Math.floor(z);
+  const tx = smoothstep(x - x0);
+  const tz = smoothstep(z - z0);
+
+  const a = hash2d(x0, z0, seed);
+  const b = hash2d(x0 + 1, z0, seed);
+  const c = hash2d(x0, z0 + 1, seed);
+  const d = hash2d(x0 + 1, z0 + 1, seed);
+
+  const ab = a + (b - a) * tx;
+  const cd = c + (d - c) * tx;
+  return ab + (cd - ab) * tz;
+}
+
+function terrainNoise(x: number, z: number, seed: number): number {
+  const broad = valueNoise(x / 48, z / 48, seed) * 2 - 1;
+  const rolling = valueNoise(x / 18, z / 18, seed + 13) * 2 - 1;
+  const detail = valueNoise(x / 7, z / 7, seed + 29) * 2 - 1;
+  return broad * 5 + rolling * 2.5 + detail * 0.8;
+}
+
+function biomeForHeight(height: number, slopeSignal: number): BiomeId {
+  if (height <= WATER_LEVEL - 1) {
+    return "shallows";
+  }
+
+  if (height <= WATER_LEVEL + 1) {
+    return "beach";
+  }
+
+  if (height >= 12 || slopeSignal > 0.72) {
+    return "rocky";
+  }
+
+  return "grassland";
+}
+
+export class TerrainGenerator {
+  private readonly seed: number;
+
+  constructor(options: TerrainGeneratorOptions = {}) {
+    this.seed = options.seed ?? 1337;
+  }
+
+  public getColumn(x: number, z: number): GeneratedColumn {
+    const noise = terrainNoise(x, z, this.seed);
+    const slopeSignal = valueNoise(x / 10, z / 10, this.seed + 101);
+    const height = clampWorldY(Math.round(7 + noise));
+    const biome = biomeForHeight(height, slopeSignal);
+
+    if (biome === "shallows" || biome === "beach") {
+      return {
+        height,
+        biome,
+        surfaceBlockId: SAND,
+        subsurfaceBlockId: SAND,
+        fluidLevel: height < WATER_LEVEL ? WATER_LEVEL : null,
+      };
+    }
+
+    if (biome === "rocky") {
+      return {
+        height,
+        biome,
+        surfaceBlockId: STONE,
+        subsurfaceBlockId: STONE,
+        fluidLevel: null,
+      };
+    }
+
+    return {
+      height,
+      biome,
+      surfaceBlockId: GRASS,
+      subsurfaceBlockId: DIRT,
+      fluidLevel: null,
+    };
+  }
+
+  public generateChunk(chunkX: number, chunkZ: number): VoxelChunk {
+    const [originX, originZ] = chunkOrigin(chunkX, chunkZ);
+    const cells: LoadedWorldCell[] = [];
+    const heightmap = createEmptyHeightmap();
+    const biomes: BiomeId[] = [];
+
+    for (let localZ = 0; localZ < CHUNK_SIZE_XZ; localZ++) {
+      for (let localX = 0; localX < CHUNK_SIZE_XZ; localX++) {
+        const worldX = originX + localX;
+        const worldZ = originZ + localZ;
+        const column = this.getColumn(worldX, worldZ);
+        const index = columnIndex(localX, localZ);
+        heightmap[index] = column.height;
+        biomes[index] = column.biome;
+
+        for (let y = WORLD_MIN_Y; y <= column.height; y++) {
+          const id =
+            y === column.height
+              ? column.surfaceBlockId
+              : y >= column.height - 3
+                ? column.subsurfaceBlockId
+                : STONE;
+          cells.push({ x: worldX, y, z: worldZ, id });
+        }
+
+        if (column.fluidLevel !== null) {
+          for (let y = column.height + 1; y <= column.fluidLevel; y++) {
+            cells.push({ x: worldX, y, z: worldZ, id: WATER });
+          }
+        }
+      }
+    }
+
+    let maxY = WATER_LEVEL;
+    for (let index = 0; index < heightmap.length; index++) {
+      maxY = Math.max(maxY, heightmap[index]);
+    }
+
+    const generatedAt = Date.now();
+    return {
+      chunkX,
+      chunkZ,
+      minY: WORLD_MIN_Y,
+      maxY,
+      cells,
+      exposedCells: cells.filter((cell) => this.hasExposedFace(cell)),
+      heightmap,
+      biomes,
+      generatedAt,
+      lastAccessedAt: generatedAt,
+    };
+  }
+
+  private hasExposedFace(cell: LoadedWorldCell): boolean {
+    const neighborOffsets = [
+      [1, 0, 0],
+      [-1, 0, 0],
+      [0, 1, 0],
+      [0, -1, 0],
+      [0, 0, 1],
+      [0, 0, -1],
+    ] as const;
+
+    return neighborOffsets.some(([dx, dy, dz]) => {
+      const neighborY = cell.y + dy;
+      if (neighborY < WORLD_MIN_Y) {
+        return false;
+      }
+
+      const neighbor = this.getColumn(cell.x + dx, cell.z + dz);
+      if (neighborY <= neighbor.height) {
+        return false;
+      }
+
+      return neighbor.fluidLevel === null || neighborY > neighbor.fluidLevel;
+    });
+  }
+}

--- a/src/game/world/world-query.ts
+++ b/src/game/world/world-query.ts
@@ -1,0 +1,23 @@
+import type { AABB } from "../core/math/aabb";
+import type { CellCoord, CollisionKind, WorldBounds } from "../core/types";
+import type { BlockDefinition } from "./block-registry";
+import type { FluidAdjacency } from "./world";
+import type { LoadedWorldCell } from "./world-loader";
+
+export interface WorldQuery {
+  getBlockIdAtCell(x: number, y: number, z: number): number;
+  getBlockAtCell(x: number, y: number, z: number): BlockDefinition;
+  getCollisionKind(x: number, y: number, z: number): CollisionKind;
+  isCellSolid(x: number, y: number, z: number): boolean;
+  isCellFluid(x: number, y: number, z: number): boolean;
+  getFluidAdjacency(x: number, y: number, z: number): FluidAdjacency;
+  getHighestSolidCell(x: number, z: number): number | null;
+  getOverlappingCells(aabb: AABB): CellCoord[];
+  collidesAABB(aabb: AABB): boolean;
+}
+
+export interface RenderableWorldQuery extends WorldQuery {
+  getBounds(): WorldBounds;
+  getRenderableCells(): LoadedWorldCell[];
+  getExposedRenderableCells(): LoadedWorldCell[];
+}

--- a/src/game/world/world.test.ts
+++ b/src/game/world/world.test.ts
@@ -3,6 +3,7 @@ import { createBodyAABB } from "../core/math/aabb";
 import { vec3 } from "../core/math/vec3";
 import { PLAYER_COLLIDER } from "../rules/constants";
 import { VoxelWorld } from "./world";
+import type { LoadedWorldCell } from "./world-loader";
 
 describe("VoxelWorld", () => {
   it("treats water as fluid but not solid", () => {
@@ -30,6 +31,29 @@ describe("VoxelWorld", () => {
       south: false,
       east: true,
       west: false,
+    });
+  });
+
+  it("returns only exposed cells for preview rendering", () => {
+    const cells: LoadedWorldCell[] = [];
+
+    for (let x = 0; x < 3; x++) {
+      for (let y = 0; y < 3; y++) {
+        for (let z = 0; z < 3; z++) {
+          cells.push({ x, y, z, id: 1 });
+        }
+      }
+    }
+
+    const world = new VoxelWorld(cells);
+
+    expect(world.getRenderableCells()).toHaveLength(27);
+    expect(world.getExposedRenderableCells()).toHaveLength(26);
+    expect(world.getExposedRenderableCells()).not.toContainEqual({
+      x: 1,
+      y: 1,
+      z: 1,
+      id: 1,
     });
   });
 

--- a/src/game/world/world.ts
+++ b/src/game/world/world.ts
@@ -25,6 +25,7 @@ function cellKey(x: number, y: number, z: number): string {
 export class VoxelWorld {
   private readonly blockIds = new Map<string, number>();
   private readonly renderableCells: LoadedWorldCell[];
+  private readonly exposedRenderableCells: LoadedWorldCell[];
   private readonly bounds: WorldBounds;
 
   constructor(cells: LoadedWorldCell[]) {
@@ -41,6 +42,10 @@ export class VoxelWorld {
       maxZ = Math.max(maxZ, cell.z);
     }
 
+    this.exposedRenderableCells = cells.filter((cell) =>
+      this.hasExposedFace(cell.x, cell.y, cell.z)
+    );
+
     this.bounds = {
       min: { x: 0, y: 0, z: 0 },
       max: { x: maxX, y: maxY, z: maxZ },
@@ -53,6 +58,21 @@ export class VoxelWorld {
 
   public getRenderableCells(): LoadedWorldCell[] {
     return this.renderableCells;
+  }
+
+  public getExposedRenderableCells(): LoadedWorldCell[] {
+    return this.exposedRenderableCells;
+  }
+
+  private hasExposedFace(x: number, y: number, z: number): boolean {
+    return (
+      this.getBlockIdAtCell(x + 1, y, z) === 0 ||
+      this.getBlockIdAtCell(x - 1, y, z) === 0 ||
+      this.getBlockIdAtCell(x, y + 1, z) === 0 ||
+      this.getBlockIdAtCell(x, y - 1, z) === 0 ||
+      this.getBlockIdAtCell(x, y, z + 1) === 0 ||
+      this.getBlockIdAtCell(x, y, z - 1) === 0
+    );
   }
 
   public getBlockIdAtCell(x: number, y: number, z: number): number {


### PR DESCRIPTION
### Motivation
- Introduce a procedural world backend with LOD and chunked terrain so the scene can run in a lightweight "preview" mode and a richer "interactive" mode.
- Provide a common query interface for both static and procedural worlds so game systems and renderers can operate against either implementation.
- Reduce render cost for previews by exposing only surface cells and enable procedural fringe rendering and runtime-driven chunk management.

### Description
- Add a `WorldQuery`/`RenderableWorldQuery` abstraction in `src/game/world/world-query.ts` and switch game systems to accept `WorldQuery` (updated `createGameState`, `input`, and `player-controller`).
- Extend `VoxelWorld` to compute and return exposed renderable cells via `getExposedRenderableCells()` and reuse this in render preview paths.
- Implement a procedural world subsystem under `src/game/world/procedural/` including `chunk-coords.ts`, `chunk.ts`, `chunk-store.ts`, `terrain-generator.ts`, `lod-policy.ts`, and `procedural-world.ts` to generate deterministic chunked terrain, manage an LRU chunk cache, and answer collision/render queries.
- Add a procedural fringe layout `computeProceduralFringeLayout` and wire it into `fringe-renderer.tsx` with toggles for particles and procedural mode.
- Update three/react components to support modes and preview detail: `WorldRenderer` gained a `detail` prop (`full` | `preview`), `World` and `Map` gained `worldMode`/`WorldMode` to select procedural vs static worlds, conditional shadows/particles are enabled based on `interactiveMode`, and `Map` now instantiates and updates a `ProceduralVoxelWorld` and drives chunk focus from the player.
- Add unit tests for procedural pieces and update world tests in `src/game/world/procedural/procedural-world.test.ts` and `src/game/world/world.test.ts` to validate generator determinism, chunk eviction, LOD policy, collision, and exposed-cell behavior.

### Testing
- Ran the unit test suite with `bun test`, which exercised `procedural-world.test.ts` and `world.test.ts` along with existing tests, and all tests passed.
- Procedural tests validated deterministic chunk generation, chunk-store eviction behavior, LOD classification, and collision/spacing queries, and they succeeded under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a246a7fcd20832399040a24c955bab5)