### PR TITLE
Refactor procedural world runtime + LOD/render snapshot, seed-preserving terrain, fringe & camera improvements

### DIFF
--- a/design-docs/1-world-refactor.md
+++ b/design-docs/1-world-refactor.md
@@ -1,0 +1,135 @@
+# 1. World Runtime Refactor Plan
+
+## Goal
+
+## Non-negotiable preview seed invariant
+
+Preview mode must continue to render the current authored static map definition as the canonical seed. Procedural terrain is allowed to branch outward from that seed, but it must not replace, reinterpret, smooth, or mutate the authored 10x10 starter area. Any runtime/refactor work must preserve this rule:
+
+```text
+preview = authored static worldData seed + procedural continuation outside seed bounds
+interactive = same seed as origin + procedural continuation as player explores
+```
+
+This invariant applies to block lookup, render snapshots, collision, fringe layout, terrain blending, and camera/presentation behavior.
+
+Create a cleaner architecture for the procedural world so future changes do not keep accumulating inside `Map`, `ProceduralVoxelWorld`, and the fringe renderer.
+
+The current prototype proves that a procedural mode can work, but several responsibilities are mixed together:
+
+- gameplay queries,
+- chunk loading,
+- terrain generation,
+- seeded-map preservation,
+- preview anchoring,
+- interactive focus following,
+- render footprint selection,
+- fringe layout,
+- player/camera presentation.
+
+This refactor should make those responsibilities explicit.
+
+## Target architecture
+
+```text
+World component
+  └─ Map component
+      └─ useWorldRuntime()
+          ├─ StaticWorldRuntime
+          └─ ProceduralWorldRuntime
+              ├─ ProceduralVoxelWorld      gameplay/block queries
+              ├─ TerrainPipeline           terrain generation
+              ├─ ChunkStore                chunk cache/lifecycle
+              ├─ LodPolicy                 fidelity classification
+              ├─ StarterRegion             seeded 10x10 map
+              └─ RenderSnapshot            render-ready terrain/fringe data
+```
+
+## New modules
+
+```text
+src/components/world/use-world-runtime.ts
+src/game/world/procedural/procedural-runtime.ts
+src/game/world/procedural/render-snapshot.ts
+src/game/world/procedural/starter-region.ts
+src/game/world/procedural/render-origin.ts
+```
+
+## Responsibility split
+
+### `ProceduralVoxelWorld`
+
+Keep this focused on `WorldQuery` behavior:
+
+- `getBlockIdAtCell`,
+- `getBlockAtCell`,
+- `getCollisionKind`,
+- `isCellSolid`,
+- `isCellFluid`,
+- `getFluidAdjacency`,
+- `getHighestSolidCell`,
+- `collidesAABB`.
+
+It should not decide how the world is rendered, how preview mode anchors, or how the camera follows.
+
+### `ProceduralWorldRuntime`
+
+Own runtime state:
+
+- current mode: preview or interactive,
+- focus position,
+- chunk window radius,
+- preview anchor,
+- interactive player-follow focus,
+- chunk ensure/evict calls,
+- render snapshot creation.
+
+### `RenderSnapshot`
+
+Bridge world simulation and rendering.
+
+Suggested shape:
+
+```ts
+interface ProceduralRenderSnapshot {
+  mode: "preview" | "interactive";
+  focus: { x: number; y: number; z: number };
+  renderOrigin: { x: number; y: number; z: number };
+  fullDetailBounds: WorldBounds;
+  highDetailCells: LoadedWorldCell[];
+  midDetailColumns: MidDetailColumn[];
+  wireColumns: WireColumn[];
+  gridTiles: FringeGridTile[];
+  particleTiles: FringeGridTile[];
+}
+```
+
+### `StarterRegion`
+
+Represent the existing 10x10 map as an authored starter region:
+
+- exact seeded block lookup,
+- seeded bounds,
+- seeded surface heights,
+- nearest seeded-edge lookup,
+- transition-skirt metadata.
+
+This keeps seed logic out of the terrain generator internals.
+
+## Implementation steps
+
+1. Add `StarterRegion` and move seed-cell indexing out of `TerrainGenerator`.
+2. Add `ProceduralWorldRuntime` and move mode/focus/chunk-window logic out of `ProceduralVoxelWorld`.
+3. Add `useWorldRuntime()` and move procedural/static world selection out of `Map`.
+4. Add `RenderSnapshot` and route procedural renderers through it.
+5. Keep static rendering unchanged until the procedural path is stable.
+6. Update tests so pure runtime functions are tested without React.
+
+## Acceptance criteria
+
+- `Map` no longer directly constructs `ProceduralVoxelWorld`.
+- Preview/starter rendering still uses the authored static `worldData` seed exactly.
+- `ProceduralVoxelWorld` only answers gameplay/world queries.
+- Preview anchoring and interactive following live in runtime/presentation modules.
+- Renderers consume explicit render snapshots instead of calling procedural world render helpers directly.
+- Static world mode continues to work unchanged.

--- a/design-docs/10-corrective-terrain-fringe-plan.md
+++ b/design-docs/10-corrective-terrain-fringe-plan.md
@@ -1,0 +1,315 @@
+# 10. Corrective Terrain, Fringe, and Fade Plan
+
+## Why this doc exists
+
+The first procedural implementation proved out the runtime/snapshot shape, but the current visual output still has several issues:
+
+- the fringe/mid-detail area is much larger than intended,
+- faded/proxy terrain can cover the camera and player,
+- water can appear elevated or unsupported relative to adjacent blocks,
+- seed-adjacent generation can still choose incompatible material bands,
+- generated terrain can still create abrupt vertical walls,
+- terrain generation should move from the current value-noise prototype toward a Perlin/simplex-family pipeline with smoothing and explicit hydrology/material constraints.
+
+This document narrows the next implementation pass. It should supersede the broad parts of docs 7-9 where they conflict.
+
+## Non-negotiable invariants
+
+1. The authored `worldData` 10x10 starter area remains exact.
+2. Trees are decorations and must not affect ground height blending.
+3. “Ground” height means the highest block whose type is one of:
+   - grass,
+   - dirt,
+   - stone,
+   - sand,
+   - water.
+4. Leaves, logs, crafting table, and other decorative/structure blocks are ignored for terrain height constraints.
+5. Water can be at or below surrounding ground/shore height, but must not float as an elevated block over unsupported air.
+6. Procedural fringe and proxy render layers must never obscure the player/camera in interactive mode.
+
+## Immediate visual constraints
+
+### Fringe size cap
+
+The visible fringe/proxy area should be small:
+
+```ts
+const MAX_FRINGE_DISTANCE_COLUMNS = 2;
+const MAX_MID_DETAIL_DISTANCE_COLUMNS = 1;
+```
+
+Meaning:
+
+- full blocks render in the current 10x10 high-detail footprint,
+- mid-detail/proxy blocks may render at most one column beyond that footprint,
+- wireframe blocks may render at most two columns beyond that footprint,
+- grid/particles can sit beyond that, but should be sparse and low opacity.
+
+This keeps the visual composition close to the original static map while still suggesting procedural continuation.
+
+### No camera/player obstruction
+
+A faded/proxy block should not render if it is between the camera and player or overlaps the player safety radius.
+
+Add snapshot culling/fade rules:
+
+```ts
+const PLAYER_VISIBILITY_RADIUS = 1.75;
+const CAMERA_OCCLUSION_CORRIDOR_RADIUS = 1.1;
+```
+
+For each non-solid visual layer candidate:
+
+1. Project the column center onto the camera-to-player segment.
+2. If the projected point is on the segment and the lateral distance is below the corridor radius, either:
+   - omit the proxy/wire element, or
+   - multiply opacity by `0.0` to `0.15`.
+3. If the column is within `PLAYER_VISIBILITY_RADIUS` of the player, omit proxy/wire rendering.
+
+This should apply to:
+
+- mid-detail translucent columns,
+- faded high-detail generated blocks outside the core full-detail footprint,
+- wireframes,
+- grid/particles near the player.
+
+The authored full-detail blocks still render normally because they are the playable surface.
+
+## Terrain generation overhaul
+
+### Move from value noise to Perlin/simplex-family fields
+
+The current terrain uses basic value noise. Replace the terrain source with layered gradient noise:
+
+```text
+src/game/world/procedural/terrain/
+  gradient-noise.ts
+  octave-noise.ts
+  fields.ts
+  height-smoothing.ts
+  hydrology.ts
+  material-zones.ts
+  seed-boundary.ts
+```
+
+Recommended algorithm family:
+
+- 2D improved Perlin noise or simplex noise for base terrain fields,
+- fractal Brownian motion (fBm) for broad terrain,
+- domain warping for less grid-aligned biome/shore boundaries,
+- low-frequency material/biome fields for gradual biome bands.
+
+Example field stack:
+
+```ts
+continentalness = fbm2(x * 0.018, z * 0.018, seedA, 4);
+erosion = fbm2(x * 0.035, z * 0.035, seedB, 3);
+moisture = fbm2(x * 0.025, z * 0.025, seedC, 3);
+temperature = fbm2(x * 0.02, z * 0.02, seedD, 3);
+localDetail = fbm2(x * 0.12, z * 0.12, seedE, 2) * 0.5;
+```
+
+Height:
+
+```ts
+baseHeight = 6 + continentalness * 4;
+erosionAdjustment = -erosion * 1.5;
+rawHeight = baseHeight + erosionAdjustment + localDetail;
+```
+
+Then clamp through the slope/smoothing pass rather than emitting directly.
+
+### Ground height from ground blocks only
+
+Add a canonical helper:
+
+```ts
+type GroundBlockId = 1 | 2 | 3 | 9 | 12;
+
+function isGroundBlockId(id: number): id is GroundBlockId {
+  return id === STONE || id === GRASS || id === DIRT || id === WATER || id === SAND;
+}
+```
+
+`StarterRegion.getHighestGroundCell(x, z)` should use only ground block IDs.
+
+Use this helper for:
+
+- seed-edge height samples,
+- nearest edge transition samples,
+- terrain smoothing constraints,
+- hydrology constraints,
+- spawn/ground classification when relevant.
+
+Do **not** use leaves/logs/tree height for sibling terrain generation.
+
+### Height smoothing / no abrupt vertical walls
+
+Use a two-pass heightfield pipeline:
+
+1. Generate raw height for an expanded chunk area with padding.
+2. Apply smoothing only to generated columns; seed columns act as fixed boundary constraints.
+
+Suggested constraints:
+
+```ts
+const MAX_GROUND_DELTA = 1;
+const MAX_TERRACE_DELTA = 2;
+```
+
+Rules:
+
+- Adjacent non-cliff ground columns should differ by at most 1 block.
+- Terraced transitions may differ by 2 blocks, but not repeatedly in a single straight vertical wall.
+- Larger cliffs require an explicit cliff classifier and should not occur in the seed transition radius.
+- Seed transition radius defaults to non-cliff behavior.
+
+Algorithm outline:
+
+```ts
+for pass in 0..2:
+  for each generated column in padded area:
+    for each cardinal neighbor:
+      if !isCliffColumn(column, neighbor):
+        column.height = clamp(
+          column.height,
+          neighbor.height - MAX_GROUND_DELTA,
+          neighbor.height + MAX_GROUND_DELTA
+        );
+```
+
+This pass should run before block emission.
+
+## Water and hydrology constraints
+
+Water should not be a floating elevated strip.
+
+### Water classification
+
+Instead of selecting water from a single column height, compute water from basin/shore context:
+
+```ts
+isWaterCandidate = height <= WATER_LEVEL && basinNoise > threshold;
+```
+
+Then enforce neighborhood support:
+
+```ts
+for each water column:
+  for each cardinal neighbor:
+    if neighbor.height < waterSurfaceY - 1:
+      lower waterSurfaceY or fill neighbor ground/shore support
+```
+
+### Water emission rules
+
+- Water fills from local terrain height + 1 up to `waterSurfaceY` only if there is solid ground underneath.
+- Water surface should be flat within a local basin.
+- A water column must have a non-air block below it.
+- Adjacent shore columns should be sand or grass/dirt, not air.
+- Do not emit water where every adjacent ground column is lower than the water surface unless the basin is also filled.
+
+### Tests for water
+
+Add tests:
+
+- no water block has air below it,
+- water columns have at least one adjacent non-air/shore support,
+- adjacent water basin surface heights are equal or differ only by an explicitly allowed waterfall feature,
+- seed-adjacent water does not float above generated terrain.
+
+## Material transition constraints
+
+Material choice should come from smooth material/biome fields, not direct per-column hard switches.
+
+### Material fields
+
+Compute continuous weights:
+
+```ts
+interface GroundMaterialWeights {
+  grass: number;
+  sand: number;
+  stone: number;
+  water: number;
+}
+```
+
+Sources:
+
+- moisture/temperature for grass vs dry/sand,
+- distance to water for beach sand,
+- slope/height for exposed stone,
+- seed-edge material weights inside transition radius.
+
+### No abrupt enclosure rule
+
+A grass/dirt region should not be immediately enclosed by sand. Enforce a minimum transition band:
+
+```ts
+const MIN_MATERIAL_TRANSITION_RADIUS = 2;
+```
+
+If a generated column chooses a material different from most adjacent ground columns:
+
+1. prefer the local majority material, or
+2. assign a transition material if one exists:
+   - grass ↔ sand: grass/dirt shore band, then sand,
+   - grass ↔ stone: dirt/grass with stone on steep sides,
+   - sand ↔ stone: sand on flat shore, stone only on steep/high columns.
+
+### Tests for material continuity
+
+- no single-column isolated sand/stone/grass spikes unless produced by an allowed decoration,
+- seed-edge grass remains surrounded by at least one band of grass/dirt before sand dominates,
+- beaches form bands near water instead of enclosing arbitrary seed terrain,
+- stone is driven by slope/height, not random adjacency.
+
+## Updated snapshot/fringe constraints
+
+### Snapshot distance limits
+
+The render snapshot builder should not scan a huge radius for near visual layers.
+
+```ts
+highDetailBounds = 10x10;
+midDetailBounds = highDetailBounds expanded by 1;
+wireBounds = highDetailBounds expanded by 2;
+horizonGridBounds = highDetailBounds expanded by 3 or 4;
+```
+
+This is enough to preserve the edge semantics without overwhelming the view.
+
+### Layer priority
+
+When multiple layers overlap:
+
+1. full blocks inside high-detail bounds,
+2. player visibility mask,
+3. mid-detail columns outside high-detail bounds only,
+4. wireframes outside high + mid bounds only,
+5. horizon grid/particles outside wire bounds only.
+
+Do not render translucent mid-detail columns over full-detail blocks.
+
+## Implementation order
+
+1. Reduce LOD/fringe search radius and band distances to 1-2 columns.
+2. Add player/camera occlusion culling for proxy/wire layers.
+3. Add `isGroundBlockId` and `StarterRegion.getHighestGroundCell`.
+4. Replace seed-edge height references with ground-only samples.
+5. Implement water support rules and tests.
+6. Implement material continuity rules and tests.
+7. Replace value-noise terrain source with Perlin/simplex-family fBm fields.
+8. Add padded heightfield smoothing before chunk emission.
+9. Re-test preview and interactive mode visually.
+
+## Acceptance criteria
+
+- Fringe is visible only just beyond the rendered area, not as a large translucent shell.
+- Player remains clearly visible; proxy/faded terrain does not cover the player or camera.
+- Water is supported by ground/shore blocks and does not float above lower adjacent terrain.
+- Seed-edge height sampling ignores trees/leaves/wood.
+- Grass/dirt, sand, stone, and water transition in coherent bands.
+- Generated terrain forms slopes/terraces instead of abrupt vertical walls.
+- The terrain algorithm uses Perlin/simplex-family gradient noise with fBm/domain-warp style fields rather than the current direct value-noise prototype.

--- a/design-docs/2-terrain-generation.md
+++ b/design-docs/2-terrain-generation.md
@@ -1,0 +1,134 @@
+# 2. Minecraft-Like Terrain Generation Plan
+
+## Goal
+
+## Seed invariant
+
+The authored static map remains the source of truth for the preview/starter area. The procedural generator must branch off that map rather than regenerate it. In practice:
+
+- every existing `worldData` cell in the 10x10 seed must remain exact,
+- seeded column heights and block IDs must be read from the authored map,
+- smoothing and biome generation may only affect non-seeded columns,
+- generated columns adjacent to the seed should blend toward the seed edge instead of altering the seed.
+
+Replace the current simple column noise with a staged, Minecraft-like terrain pipeline that produces smoother height transitions and more coherent block/biome changes.
+
+Adjacent blocks should not abruptly change height or material unless the terrain intentionally enters a cliff/mountain feature.
+
+## Current problem
+
+The current generator chooses height and biome directly from a small number of noise samples. This can cause:
+
+- abrupt height cliffs,
+- one-column material spikes,
+- harsh grass/sand/stone boundaries,
+- generated terrain that does not blend cleanly into the seeded 10x10 starter map.
+
+## Target generation pipeline
+
+```text
+seed
+  ↓
+climate fields
+  temperature, humidity, continentalness
+  ↓
+terrain fields
+  base height, erosion, peaks/valleys, detail
+  ↓
+biome selection
+  plains, beach, shallows, rocky hills, water
+  ↓
+height smoothing
+  neighborhood-aware pass with chunk borders
+  ↓
+surface material pass
+  grass/dirt/sand/stone/water by biome + slope + waterline
+  ↓
+chunk cell emission
+```
+
+## Proposed modules
+
+```text
+src/game/world/procedural/terrain/
+  noise.ts
+  climate.ts
+  heightfield.ts
+  biomes.ts
+  surface.ts
+  seed-transition.ts
+```
+
+## Terrain fields
+
+Use multiple low-frequency fields instead of one direct height function:
+
+- `continentalness`: controls land vs water mass.
+- `erosion`: lowers/smooths terrain and produces valleys.
+- `peaks`: raises hills/mountains.
+- `detail`: small local variation, applied after smoothing and clamped.
+
+Suggested height formula:
+
+```ts
+baseHeight = waterLevel + continentalness * 6;
+erodedHeight = baseHeight - erosion * 3;
+peakHeight = peaks > threshold ? (peaks - threshold) * 8 : 0;
+rawHeight = erodedHeight + peakHeight + detail;
+```
+
+Then apply a smoothing/quantization pass.
+
+## Height smoothing rules
+
+1. Generate each chunk with a border of at least one column around it.
+2. Smooth isolated pits/spikes.
+3. Clamp most neighboring column deltas to 1 or 2 blocks.
+4. Allow larger deltas only if a cliff classifier says the area is rocky/mountainous.
+5. Ensure chunk boundaries use the same samples so adjacent chunks match.
+
+## Biome and material transitions
+
+Biome selection should be gradual:
+
+- water/shallows near or below water level,
+- beach near waterline,
+- grassland inland,
+- rocky hills where slope/height are high.
+
+Surface material rules:
+
+- Waterline columns use sand near shore.
+- Grassland uses grass on top, dirt below, stone deeper.
+- Rocky slopes expose stone on steep or high terrain.
+- Transitions should be based on neighborhood/slope, not isolated random choice.
+
+## Seeded 10x10 starter region
+
+The existing map should remain exact inside the seeded area.
+
+Outside the seed, add a transition skirt:
+
+- `SEED_BLEND_RADIUS`, for example 8 columns.
+- Nearest seeded edge height influences generated height.
+- Generated terrain height is blended toward seeded edge height near the starter area.
+- Material preferences are blended from nearest seeded surface material.
+
+## Tests
+
+Add or update tests in `src/game/world/procedural/procedural-world.test.ts`:
+
+- deterministic generation with same seed,
+- chunk boundary continuity,
+- neighboring generated column height delta stays within configured threshold,
+- seed cells remain exact and are never smoothed/replaced,
+- seed transition skirt does not create abrupt cliffs,
+- beach/grass/stone transitions do not create one-column spikes,
+- water level remains stable across adjacent columns.
+
+## Acceptance criteria
+
+- Adjacent generated columns rarely differ by more than 1-2 blocks except in classified cliffs.
+- Biome/material changes happen in bands rather than isolated cells.
+- The starter 10x10 map remains exact and is the visible preview seed.
+- Terrain outside the starter map blends smoothly into the authored seed area.

--- a/design-docs/3-lod-render-snapshot.md
+++ b/design-docs/3-lod-render-snapshot.md
@@ -1,0 +1,127 @@
+# 3. LOD and Render Snapshot Plan
+
+## Goal
+
+## Seed/render invariant
+
+The high-detail preview/starter footprint is the authored static 10x10 map. Render snapshots must treat those seed cells as canonical high-detail cells and build mid-detail, wireframe, grid, and particle bands outward from that seed footprint. The LOD system should never swap the seed for generated terrain in preview mode.
+
+Make LOD the single source of truth for what gets rendered as full blocks, mid-detail terrain, wireframes, grid, and particles.
+
+The current procedural path has high-detail blocks and a fringe perimeter, but it does not yet model a continuous fidelity transition.
+
+## Target fidelity bands
+
+```text
+10x10 full-detail footprint
+  → high-detail textured blocks
+near ring
+  → simplified/mid-detail terrain columns
+outer ring
+  → wireframe terrain columns
+horizon ring
+  → sparse grid and particles
+unloaded
+  → no render data
+```
+
+## LodPolicy responsibilities
+
+Extend `src/game/world/procedural/lod-policy.ts` so it can answer:
+
+```ts
+interface LodSample {
+  lod: "high" | "mid" | "wire" | "horizon" | "unloaded";
+  fidelity: number;
+  blockOpacity: number;
+  midOpacity: number;
+  wireOpacity: number;
+  particleOpacity: number;
+  distanceFromFullDetail: number;
+}
+```
+
+The policy should work at column/cell distance from the full-detail footprint, not only chunk distance.
+
+## Render snapshot
+
+Add `src/game/world/procedural/render-snapshot.ts`.
+
+Suggested types:
+
+```ts
+interface MidDetailColumn {
+  x: number;
+  z: number;
+  y: number;
+  height: number;
+  surfaceBlockId: number;
+  biome: BiomeId;
+  opacity: number;
+}
+
+interface WireColumn {
+  x: number;
+  z: number;
+  minY: number;
+  maxY: number;
+  opacity: number;
+  fidelity: number;
+}
+
+interface ProceduralRenderSnapshot {
+  highDetailCells: LoadedWorldCell[];
+  midDetailColumns: MidDetailColumn[];
+  wireColumns: WireColumn[];
+  gridTiles: FringeGridTile[];
+  particleTiles: FringeGridTile[];
+}
+```
+
+## Rendering layers
+
+### High detail
+
+Use the existing `WorldRenderer` path initially:
+
+- seeded 10x10 map,
+- fully textured blocks,
+- collision-authored terrain.
+
+Eventually replace per-block React rendering with chunk-instanced meshes.
+
+### Mid detail
+
+Add a simplified renderer:
+
+```text
+src/adapters/three/procedural-mid-detail-renderer.tsx
+```
+
+It should render:
+
+- top surfaces,
+- simplified side columns,
+- biome/surface color or existing texture,
+- fading opacity based on `LodSample.midOpacity`.
+
+### Wire/horizon
+
+Wireframe and grid should come from the same snapshot, not an independent perimeter calculation.
+
+## Implementation steps
+
+1. Extend `LodPolicy` with column-distance/fidelity helpers.
+2. Add `RenderSnapshot` types and builder.
+3. Make `ProceduralWorldRuntime` build snapshots from chunk data and LOD samples.
+4. Update `Map` to render snapshot layers.
+5. Keep static `WorldRenderer` unchanged.
+6. Add tests that snapshot classification matches LOD policy.
+
+## Acceptance criteria
+
+- Full blocks render only inside the high-detail footprint, and the preview high-detail footprint is the authored static seed.
+- Mid-detail terrain appears outside full-detail blocks.
+- Wireframes appear outside mid-detail terrain.
+- Opacity/fidelity changes by distance instead of fixed hardcoded rows.
+- Terrain renderer and fringe renderer agree on LOD classification.

--- a/design-docs/4-fringe-wireframes.md
+++ b/design-docs/4-fringe-wireframes.md
@@ -1,0 +1,113 @@
+# 4. Fringe Wireframe and Fidelity Transition Plan
+
+## Goal
+
+## Seed/fringe invariant
+
+Procedural fringe bands must begin outside the authored static seed footprint. The current 10x10 map remains the high-fidelity seed in preview mode; wireframes, mid-detail terrain, and horizon effects are continuations that branch outward from that seed rather than replacements for it.
+
+Fix procedural fringe behavior so wireframes actually represent a low-fidelity frontier that resolves into higher-fidelity terrain near the render zone.
+
+The current procedural fringe is effectively a fixed perimeter around the 10x10 footprint. It does not fade out of fidelity at the edge or become higher fidelity as it approaches the rendered area.
+
+## Desired behavior
+
+Approaching the full-detail zone:
+
+```text
+horizon particles/grid
+  → wireframe terrain columns
+  → translucent mid-detail columns
+  → fully rendered blocks
+```
+
+Leaving the full-detail zone:
+
+```text
+fully rendered blocks
+  → mid-detail columns
+  → wireframe columns
+  → sparse grid/particles
+```
+
+## Problems to solve
+
+- Procedural wireframes use mostly fixed opacity.
+- Fringe layout is derived from `world.getBounds()` rather than LOD bands.
+- The shader only performs camera/back/lateral fade.
+- No per-line fidelity attribute exists.
+- Grid rows and particles are not tied to terrain LOD.
+
+## Layout changes
+
+Refactor `src/components/world/fringe/procedural-fringe-layout.ts` to consume render snapshot or LOD samples.
+
+Suggested `FringeWireframe` additions:
+
+```ts
+interface FringeWireframe {
+  x: number;
+  y: number;
+  z: number;
+  opacity: number;
+  fidelity?: number;
+  distanceBand?: number;
+}
+```
+
+Suggested `FringeGridTile` additions:
+
+```ts
+interface FringeGridTile {
+  x: number;
+  z: number;
+  opacity: number;
+  row: number;
+  outward: [number, number];
+  emissionWeight: number;
+  fidelity?: number;
+}
+```
+
+## Geometry changes
+
+Update `src/components/world/fringe/fringe-line-geometry.ts`:
+
+- add `fidelity` buffer attribute,
+- add `distanceBand` buffer attribute,
+- continue supporting static layout defaults.
+
+## Shader changes
+
+Update `src/components/world/fringe/fringe-line-field.tsx`:
+
+- read `fidelity` and/or `distanceBand`,
+- multiply opacity by LOD-derived fade,
+- optionally pulse low-fidelity wireframes,
+- keep existing camera-facing fade.
+
+## Particle changes
+
+Particle emission should derive from the far/horizon band:
+
+- no particles in full-detail or mid-detail areas,
+- more particles in horizon/grid rows,
+- disabled or low budget in preview mode,
+- enabled in interactive mode only if budget allows.
+
+## Tests
+
+Update `src/components/world/fringe/procedural-fringe-layout.test.ts`:
+
+- inner wire band starts outside full-detail footprint,
+- wire opacity changes by distance,
+- horizon/grid opacity fades out,
+- no fixed opacity for every procedural wireframe,
+- particle tiles come only from horizon/far bands.
+
+## Acceptance criteria
+
+- Wireframes are not visually fixed around the map.
+- Near generated terrain resolves into blocks/mid-detail while the authored seed remains high fidelity.
+- Far terrain fades to grid/particles.
+- Static fringe behavior remains unchanged.

--- a/design-docs/5-camera-presentation.md
+++ b/design-docs/5-camera-presentation.md
@@ -1,0 +1,106 @@
+# 5. Camera and Presentation Mode Plan
+
+## Goal
+
+## Preview seed invariant
+
+Preview presentation must keep the authored static seed as the stable visual anchor. The player/autoplay can move within that fixed seed scene, while procedural terrain branches outward beyond the seed. Interactive camera-follow or render-origin behavior must not change the authored preview seed layout.
+
+Prevent the player from going off screen in interactive mode while preserving the current portfolio-style preview behavior.
+
+Preview and interactive mode should have different presentation rules.
+
+## Desired mode behavior
+
+| Mode | Player | Camera / map | Purpose |
+| --- | --- | --- | --- |
+| Preview | Player/autoplay moves within staged scene | Map remains fixed or rotates | Portfolio preview |
+| Interactive | Player remains framed or centered | Camera follows or world recenters | Playable world |
+| Procedural infinite | Player drives chunk focus | Render origin follows player | Infinite terrain stability |
+
+## Short-term fix: follow camera
+
+Add a camera-follow helper for interactive mode.
+
+Suggested file:
+
+```text
+src/components/world/player-camera-follow.tsx
+```
+
+Behavior:
+
+- disabled in preview mode,
+- enabled in interactive mode,
+- reads `gameStateRef.current.player.position`,
+- lerps camera to a third-person offset,
+- calls `camera.lookAt(player.x, player.y + 1, player.z)`.
+
+Example camera offset:
+
+```ts
+const offset = { x: 8, y: 6, z: 8 };
+```
+
+## Long-term fix: render origin
+
+For infinite procedural terrain, use a render origin rather than rendering all objects at large simulation coordinates.
+
+Simulation coordinates remain real:
+
+```text
+player.position = world-space position
+collision uses world-space position
+chunks load around world-space position
+```
+
+Presentation coordinates are rebased:
+
+```text
+renderOrigin = player.position in interactive mode
+terrain renders at cell.position - renderOrigin
+player renders near visual center
+camera stays near visual center
+```
+
+Suggested file:
+
+```text
+src/game/world/procedural/render-origin.ts
+```
+
+## Preview rules
+
+Preview mode should not recenter on the player:
+
+- map remains fixed,
+- player/autoplay moves around the seeded 10x10 scene,
+- procedural focus can remain anchored to preview center,
+- no camera-follow behavior.
+
+## Interactive rules
+
+Interactive mode should keep the player visible:
+
+- initially use follow camera,
+- later switch procedural mode to player-centered render origin,
+- update procedural chunk focus from player simulation position,
+- keep world/collision simulation unchanged.
+
+## Implementation steps
+
+1. Add follow camera helper and enable it only in interactive mode.
+2. Add presentation mode type:
+   - `preview-fixed`,
+   - `interactive-follow-camera`,
+   - future `interactive-centered-origin`.
+3. Extract presentation selection into `useWorldRuntime()`.
+4. Add render-origin abstraction for procedural interactive mode.
+5. Update render snapshots to store both simulation coordinates and render-relative coordinates.
+
+## Acceptance criteria
+
+- In preview mode, the world looks like a fixed portfolio scene rooted in the authored static seed.
+- In interactive mode, the player stays in frame.
+- Procedural chunk focus follows the player only in interactive mode.
+- The system is ready for render-origin recentering without rewriting physics.

--- a/design-docs/6-implementation-roadmap.md
+++ b/design-docs/6-implementation-roadmap.md
@@ -1,0 +1,149 @@
+# 6. Implementation Roadmap
+
+## Recommended order
+
+## Global invariant
+
+All milestones must preserve this invariant: the current static `worldData` map is the exact preview/starter seed, and procedural generation branches outward from it. The seed must remain exact for rendering, collision, block lookup, LOD classification, and fringe placement.
+
+### 1. Runtime refactor
+
+Implement `useWorldRuntime`, `ProceduralWorldRuntime`, `StarterRegion`, and `RenderSnapshot`.
+
+Why first:
+
+- reduces coupling,
+- gives terrain/fringe/camera work clean integration points,
+- prevents `Map` and `ProceduralVoxelWorld` from growing further.
+
+### 2. Short-term interactive camera follow
+
+Add an interactive follow camera before the render-origin system.
+
+Why second:
+
+- quickly fixes the player going off screen,
+- low risk,
+- does not block deeper architecture.
+
+### 3. Seed-transition terrain fix
+
+Implement the transition-skirt terrain plan in `7-seed-transition-terrain.md` before expanding farther from the seed.
+
+Why third:
+
+- fixes the visible cliffs/material jumps immediately adjacent to the authored map,
+- keeps the seed exact while making generated terrain respect seed-edge boundary conditions,
+- can be tested as pure height/material field logic.
+
+### 4. LOD policy and render snapshot
+
+Make LOD classification and fidelity values shared between renderers and fringe. Use the continuous opacity model in `9-seamless-fidelity-transitions.md`.
+
+Why fourth:
+
+- fixes block pop-in/pop-out,
+- prepares mid-detail rendering,
+- makes procedural rendering deterministic and testable.
+
+### 5. Camera-relative fringe refactor
+
+Use snapshot/LOD/camera data to drive wireframe and grid placement as described in `8-camera-relative-fringe.md`.
+
+Why fifth:
+
+- depends on LOD policy,
+- removes hardcoded procedural perimeter behavior,
+- makes the frontier move with the interactive player/camera.
+
+### 6. Minecraft-like terrain pipeline
+
+Refactor terrain generation into climate, heightfield, biome, surface, and seed-transition stages.
+
+Why sixth:
+
+- larger change,
+- easier once the runtime/snapshot boundaries exist,
+- extends the seed-transition fix to the full world.
+
+### 7. Mid-detail terrain renderer
+
+Add simplified terrain columns between full-detail blocks and wireframes.
+
+Why seventh:
+
+- depends on render snapshots and LOD fidelity,
+- completes the visual transition from wireframe to blocks.
+
+### 8. Player-centered render origin
+
+Replace or augment follow camera with render-origin recentering for infinite interactive terrain.
+
+Why eighth:
+
+- best long-term architecture,
+- easier after snapshots separate simulation and presentation coordinates.
+
+## Milestone checklist
+
+### Milestone A: Architecture foundation
+
+- [ ] `StarterRegion` owns seeded 10x10 map and preserves it exactly.
+- [ ] `ProceduralWorldRuntime` owns mode/focus/chunk window.
+- [ ] `RenderSnapshot` exists.
+- [ ] `Map` consumes runtime output.
+- [ ] Static mode still works.
+
+### Milestone B: Player framing
+
+- [ ] Interactive follow camera exists.
+- [ ] Preview mode remains fixed.
+- [ ] Reset key resets player and presentation state.
+
+### Milestone C: Seed-transition terrain
+
+- [ ] Seed edge samples are available from `StarterRegion`.
+- [ ] Generated columns near the seed blend toward seed-edge heights.
+- [ ] Generated materials near the seed blend toward seed-edge material weights.
+- [ ] Seed cells remain exact and immutable.
+
+### Milestone D: LOD/fringe/fade
+
+- [ ] `LodPolicy` returns discrete LOD and continuous fidelity.
+- [ ] Render snapshots include opacity for high/mid/wire/particle layers.
+- [ ] Procedural fringe consumes LOD/snapshot/camera data.
+- [ ] Wireframe opacity changes by distance and camera relevance.
+- [ ] Blocks and wireframes overlap during fade transitions.
+- [ ] Particles only emit in far/horizon band.
+
+### Milestone E: Terrain quality
+
+- [ ] Heightfield smoothing implemented.
+- [ ] Biome transitions are gradual.
+- [ ] Seed transition skirt implemented.
+- [ ] Chunk boundary tests pass.
+
+### Milestone F: Render quality
+
+- [ ] Mid-detail renderer exists.
+- [ ] High/mid/wire/horizon bands transition smoothly.
+- [ ] Render origin supports infinite interactive movement.
+
+## Validation commands
+
+Run after each milestone:
+
+```bash
+bun run lint
+bun test
+bun run build
+```
+
+Manual validation:
+
+- preview mode remains stable,
+- interactive player stays framed,
+- seeded 10x10 area exactly matches current static map,
+- generated terrain does not cliff abruptly near seed,
+- wireframes fade from horizon into higher-fidelity terrain,
+- mobile WASD still controls the player on `/world`.

--- a/design-docs/6-implementation-roadmap.md
+++ b/design-docs/6-implementation-roadmap.md
@@ -26,15 +26,16 @@ Why second:
 - low risk,
 - does not block deeper architecture.
 
-### 3. Seed-transition terrain fix
+### 3. Corrective terrain/fringe pass
 
-Implement the transition-skirt terrain plan in `7-seed-transition-terrain.md` before expanding farther from the seed.
+Implement the immediate corrective plan in `10-corrective-terrain-fringe-plan.md` before expanding farther from the seed. This includes the smaller fringe, player/camera occlusion mask, ground-only seed sampling, water support rules, material transition bands, and Perlin/simplex-family terrain fields.
 
 Why third:
 
-- fixes the visible cliffs/material jumps immediately adjacent to the authored map,
-- keeps the seed exact while making generated terrain respect seed-edge boundary conditions,
-- can be tested as pure height/material field logic.
+- fixes the oversized fringe and player-obscuring faded terrain,
+- fixes visible cliffs/material jumps immediately adjacent to the authored map,
+- keeps the seed exact while making generated terrain respect ground-only seed-edge boundary conditions,
+- can be tested as pure height/material/hydrology field logic.
 
 ### 4. LOD policy and render snapshot
 
@@ -102,9 +103,12 @@ Why eighth:
 
 ### Milestone C: Seed-transition terrain
 
-- [ ] Seed edge samples are available from `StarterRegion`.
-- [ ] Generated columns near the seed blend toward seed-edge heights.
+- [ ] Seed edge samples use ground blocks only.
+- [ ] Generated columns near the seed blend toward seed-edge ground heights.
 - [ ] Generated materials near the seed blend toward seed-edge material weights.
+- [ ] Water has ground/shore support and does not float.
+- [ ] Fringe/proxy bands are capped to 1-2 columns outside high detail.
+- [ ] Player/camera occlusion masks hide proxy/fade layers near the player.
 - [ ] Seed cells remain exact and immutable.
 
 ### Milestone D: LOD/fringe/fade
@@ -118,9 +122,11 @@ Why eighth:
 
 ### Milestone E: Terrain quality
 
-- [ ] Heightfield smoothing implemented.
-- [ ] Biome transitions are gradual.
-- [ ] Seed transition skirt implemented.
+- [ ] Perlin/simplex-family fBm fields implemented.
+- [ ] Heightfield smoothing clamps non-cliff adjacent ground deltas.
+- [ ] Biome/material transitions are gradual bands.
+- [ ] Seed transition skirt implemented with ground-only samples.
+- [ ] Hydrology support tests pass.
 - [ ] Chunk boundary tests pass.
 
 ### Milestone F: Render quality

--- a/design-docs/7-seed-transition-terrain.md
+++ b/design-docs/7-seed-transition-terrain.md
@@ -1,0 +1,198 @@
+# 7. Seed-Transition Terrain Fix Plan
+
+## Problem statement
+
+The current procedural terrain can branch away from the authored 10x10 starter seed with sharp height cliffs and abrupt material swaps. This creates visible columns where grass, sand, stone, and water appear next to incompatible seed blocks, and it makes the procedural continuation look pasted onto the starter island instead of grown from it.
+
+The fix is **not** to smooth or mutate the seed. The authored 10x10 block layout remains canonical. The generator must instead treat the seed edge as boundary conditions for the surrounding heightfield and material field.
+
+## Invariant
+
+- Every authored `worldData` cell inside the starter footprint remains exact.
+- Seed columns are never smoothed, quantized, regenerated, or reclassified.
+- Procedural columns adjacent to the seed are generated from the same terrain algorithm as the rest of the world, then blended toward seed-edge height/material constraints.
+- Collision and rendering must query the same blended/generated column data.
+
+## Current failure mode
+
+```text
+seed column height/material
+  ↓ hard boundary
+procedural noise height/material
+  ↓ no transition skirt
+abrupt cliff or one-column material mismatch
+```
+
+This happens because the current generator has only two states:
+
+1. exact seeded column,
+2. unconstrained procedural column.
+
+There is no “near seed” transition state.
+
+## Target generation model
+
+```text
+StarterRegion
+  ↓ exposes edge columns and nearest-edge samples
+BaseTerrainField
+  ↓ computes raw Minecraft-like terrain away from seed
+SeedTransitionField
+  ↓ blends raw height/material toward seed boundary conditions
+SmoothingPass
+  ↓ removes spikes/pits while respecting immutable seed cells
+SurfacePass
+  ↓ assigns block stacks from blended biome/material fields
+ChunkEmission
+```
+
+## Seed transition skirt
+
+Add a configurable transition skirt outside the starter footprint:
+
+```ts
+const SEED_HEIGHT_BLEND_RADIUS = 10;
+const SEED_MATERIAL_BLEND_RADIUS = 6;
+const MAX_NON_CLIFF_NEIGHBOR_DELTA = 2;
+```
+
+For any non-seed column `(x, z)`:
+
+1. Compute distance to starter footprint.
+2. Find the nearest seed-edge column or the nearest few seed-edge columns.
+3. Compute raw procedural height/material.
+4. Compute blend weight:
+
+```ts
+seedWeight = 1 - smoothstep(0, SEED_HEIGHT_BLEND_RADIUS, distanceToSeedEdge);
+```
+
+5. Blend height:
+
+```ts
+blendedHeight = round(lerp(rawHeight, seedEdgeHeight + edgeSlopeOffset, seedWeight));
+```
+
+`edgeSlopeOffset` should allow gentle outward slopes instead of forcing all nearby generated columns to equal the seed height.
+
+Suggested offset:
+
+```ts
+edgeSlopeOffset = clamp(distanceToSeedEdge * preferredSlope, -3, 3);
+preferredSlope = rawHeight > seedEdgeHeight ? 0.35 : -0.25;
+```
+
+## Neighbor continuity pass
+
+After base blending, run a local smoothing pass over generated columns only:
+
+```ts
+for each generated column:
+  for each cardinal neighbor:
+    if neither side is classified cliff:
+      clamp height delta to MAX_NON_CLIFF_NEIGHBOR_DELTA
+```
+
+Important details:
+
+- Seed columns participate as fixed neighbors but are never modified.
+- Chunk generation must sample a padding border so smoothing produces identical results across chunk boundaries.
+- Cliffs are allowed only where a low-frequency cliff/rocky classifier says the area is steep.
+- The transition skirt near the seed should default to non-cliff behavior unless the authored seed itself has a steep edge.
+
+## Material transition field
+
+Do not assign materials from height alone. Add a material preference field blended from seed-edge materials:
+
+```ts
+interface MaterialWeights {
+  grass: number;
+  dirt: number;
+  sand: number;
+  stone: number;
+  water: number;
+}
+```
+
+For non-seed columns near the starter footprint:
+
+```ts
+materialWeights = mix(rawBiomeWeights, seedEdgeMaterialWeights, materialSeedWeight);
+```
+
+Rules:
+
+- Seed-edge grass should produce nearby grass/dirt before transitioning to other biomes.
+- Seed-edge sand/water should produce beach/shore bands before open water or grassland.
+- Seed-edge stone should allow nearby rocky faces but should not create giant vertical stone slabs unless height/slope requires it.
+- Top block choice should be based on blended weights and local slope, not a single raw noise threshold.
+
+## Implementation outline
+
+### 1. Extend `StarterRegion`
+
+Add helpers:
+
+```ts
+getNearestEdgeSample(x, z): SeedEdgeSample;
+getEdgeMaterialWeights(x, z): MaterialWeights;
+getDistanceToFootprint(x, z): number;
+isInsideFootprint(x, z): boolean;
+```
+
+`SeedEdgeSample` should include:
+
+```ts
+interface SeedEdgeSample {
+  x: number;
+  z: number;
+  height: number;
+  surfaceBlockId: number;
+  materialWeights: MaterialWeights;
+  distance: number;
+}
+```
+
+### 2. Split terrain generation stages
+
+Create or refactor toward:
+
+```text
+src/game/world/procedural/terrain/
+  base-fields.ts
+  seed-transition.ts
+  smoothing.ts
+  surface-materials.ts
+```
+
+### 3. Generate chunks with padding
+
+For chunk `(chunkX, chunkZ)`, generate a padded height/material field:
+
+```ts
+padding = 2;
+area = chunk area expanded by padding;
+```
+
+Use the padded area for smoothing, then emit only the real chunk area.
+
+### 4. Preserve seed exactly in emission
+
+If `(x, z)` is a seed column, emit `StarterRegion.getColumnCells(x, z)` exactly and skip procedural surface emission.
+
+## Tests
+
+Add tests for:
+
+- seed cells remain exact after transition and smoothing,
+- generated columns adjacent to seed do not exceed configured height delta unless classified cliff,
+- terrain height continuity across chunk boundaries with seed skirt active,
+- material bands near seed edge match the seed edge before transitioning outward,
+- water/sand/grass transitions do not create isolated one-column material spikes.
+
+## Acceptance criteria
+
+- No large procedural wall appears immediately adjacent to the starter seed unless the authored seed edge already implies a cliff.
+- Generated terrain visibly slopes or terraces away from seed-edge heights.
+- Material transitions near the seed are locally coherent.
+- The starter 10x10 area remains visually identical to the static map.

--- a/design-docs/8-camera-relative-fringe.md
+++ b/design-docs/8-camera-relative-fringe.md
@@ -1,0 +1,137 @@
+# 8. Camera-Relative Fringe Fix Plan
+
+## Problem statement
+
+The procedural wireframe fringe is currently tied to the starter/full-detail footprint in world coordinates. As the player and camera move, the wireframes remain visually fixed instead of behaving like a camera-relative frontier where distant terrain is low fidelity and near terrain resolves to higher fidelity.
+
+The fringe should be computed from **view-relative distance and LOD state**, not from a static perimeter around `world.getBounds()`.
+
+## Invariant
+
+- Preview mode may keep the authored seed visually centered/fixed.
+- Interactive mode should evaluate fringe placement relative to the current camera/player focus.
+- The high-detail authored seed remains exact when the focus is within the starter region.
+- Generated fringe data must come from the same terrain generator and render snapshot as high/mid-detail terrain.
+
+## Current failure mode
+
+```text
+computeProceduralFringeLayout(world.getBounds())
+  → fixed rows around footprint
+  → wireframes do not move with camera/focus
+  → opacity is mostly static
+```
+
+This makes the fringe look like a permanent cage rather than a procedural horizon.
+
+## Target model
+
+```text
+camera/player focus
+  ↓
+render origin / view frame
+  ↓
+LOD samples by column distance and screen relevance
+  ↓
+render snapshot bands
+  ↓
+fringe geometry + shader attributes
+```
+
+## Coordinate spaces
+
+Define three explicit spaces:
+
+1. **World space**: canonical simulation/generation coordinates.
+2. **Render space**: world coordinates minus `renderOrigin`, used for Three.js object positions.
+3. **View space**: render-space coordinates transformed by camera orientation for visibility/fade calculations.
+
+Fringe generation should classify columns in world space, position them in render space, and fade them in view space.
+
+## Camera-relative LOD anchor
+
+In interactive mode, use the player/camera focus as the center of the LOD field:
+
+```ts
+lodFocus = gameState.player.position;
+```
+
+In preview mode, use the starter seed center:
+
+```ts
+lodFocus = starterRegion.center;
+```
+
+The full-detail footprint remains 10x10, but in interactive mode that footprint should follow `lodFocus` once the system supports generated terrain beyond the seed.
+
+## Fringe band selection
+
+Instead of hardcoded rows from bounds, sample columns in a ring around the current high-detail footprint:
+
+```ts
+for x/z in visibleCandidateArea:
+  sample = lodPolicy.sampleColumn({ x, z, focus, camera });
+  if sample.lod === "wire" or "horizon":
+    add wire/grid/particle element
+```
+
+Candidate area should be bounded by render budget:
+
+```ts
+wireRadiusColumns = 18;
+horizonRadiusColumns = 28;
+```
+
+## View relevance and camera fading
+
+Use camera-relative weighting before creating or rendering wireframes:
+
+```ts
+viewDirectionWeight = saturate(dot(normalize(column - camera), cameraForward));
+lateralWeight = 1 - smoothstep(maxLateralDistance * 0.7, maxLateralDistance, lateralDistance);
+distanceWeight = lodPolicy.wireOpacity;
+finalOpacity = distanceWeight * viewDirectionWeight * lateralWeight;
+```
+
+This avoids dense wireframes behind the player/camera and prevents fixed full-opacity cages.
+
+## Snapshot additions
+
+Add camera/focus metadata to `ProceduralRenderSnapshot`:
+
+```ts
+interface ProceduralRenderSnapshot {
+  focus: Vec3;
+  cameraPosition: Vec3;
+  cameraForward: Vec3;
+  renderOrigin: Vec3;
+  highDetailBounds: WorldBounds;
+  lodSamples: LodSample[];
+  wireColumns: WireColumn[];
+  gridTiles: FringeGridTile[];
+  particleTiles: FringeGridTile[];
+}
+```
+
+## Renderer changes
+
+- `ProceduralWorldRuntime` should accept focus/camera context each frame.
+- `computeProceduralFringeLayout` should consume snapshot data instead of `world.getBounds()`.
+- `FringeRenderer` should render snapshot wire/grid/particle elements.
+- Existing static fringe layout can remain unchanged for static mode.
+
+## Tests
+
+Add tests that:
+
+- moving focus shifts procedural fringe candidates,
+- moving camera changes wire opacity/view relevance,
+- wireframes are not all equal opacity,
+- wireframes behind the camera are reduced or omitted,
+- preview mode remains anchored to the starter seed center.
+
+## Acceptance criteria
+
+- In interactive mode, wireframes advance with the player/camera instead of staying fixed to the initial seed perimeter.
+- The densest wireframes appear near the visible frontier, not behind or underneath the player.
+- Preview mode still uses the static seed as the fixed high-detail anchor.

--- a/design-docs/9-seamless-fidelity-transitions.md
+++ b/design-docs/9-seamless-fidelity-transitions.md
@@ -1,0 +1,169 @@
+# 9. Seamless Block-to-Wire Fidelity Transition Plan
+
+## Problem statement
+
+Blocks currently clip into and out of existence when the active full-detail footprint changes. Wireframes and blocks are separate hard bands, so terrain does not gradually resolve from wireframe to rendered blocks or dissolve back to wireframe as the player moves.
+
+The fix is to make **continuous fidelity** the shared source of truth for all render layers.
+
+## Invariant
+
+- Full-resolution collision and seed blocks remain authoritative.
+- The authored starter seed is fully opaque/high fidelity in preview mode.
+- Outside the full-detail footprint, generated terrain should pass through mid-detail and wireframe states instead of popping.
+- Fading should be visual only; collision availability must remain conservative and should not fade.
+
+## Current failure mode
+
+```text
+column enters full-detail footprint
+  → render block immediately
+column leaves full-detail footprint
+  → remove block immediately
+wireframe perimeter separately rendered
+  → no crossfade with blocks
+```
+
+## Target transition
+
+For each terrain column/cell, compute a continuous fidelity value:
+
+```ts
+fidelity = 1 - smoothstep(fullStart, wireEnd, distanceFromHighDetailZone);
+```
+
+Then derive layer opacities:
+
+```ts
+blockOpacity = smoothstep(0.72, 1.0, fidelity);
+midOpacity = 1 - abs(fidelity - 0.55) / 0.45;
+wireOpacity = 1 - smoothstep(0.25, 0.72, fidelity);
+particleOpacity = 1 - smoothstep(0.0, 0.25, fidelity);
+```
+
+Expected visual progression:
+
+```text
+fidelity 1.00: opaque textured blocks
+fidelity 0.70: blocks fading, mid columns visible
+fidelity 0.50: translucent mid-detail terrain dominates
+fidelity 0.25: mid columns fading, wireframes dominate
+fidelity 0.00: sparse grid/particles only
+```
+
+## Hysteresis and transition state
+
+Distance-only opacity still flickers at band boundaries if the focus moves back and forth. Add per-column visual state:
+
+```ts
+interface ColumnVisualState {
+  key: string;
+  currentLod: ChunkLod;
+  previousLod: ChunkLod | null;
+  enteredAtMs: number;
+  lastSeenAtMs: number;
+  transitionDurationMs: number;
+}
+```
+
+Blend final opacity with transition progress:
+
+```ts
+transitionProgress = smoothstep(0, duration, now - enteredAtMs);
+finalOpacity = mix(previousOpacity, targetOpacity, transitionProgress);
+```
+
+Use hysteresis radii:
+
+```ts
+highEnterRadius = 5.0 columns;
+highExitRadius = 6.5 columns;
+midEnterRadius = 10.0 columns;
+midExitRadius = 12.0 columns;
+```
+
+## Render snapshot requirements
+
+Render snapshot should contain all active visual layers for overlapping transition bands:
+
+```ts
+interface ProceduralRenderSnapshot {
+  highDetailCells: HighDetailCell[];   // includes opacity
+  midDetailColumns: MidDetailColumn[]; // includes opacity
+  wireColumns: WireColumn[];           // includes opacity/fidelity
+  particleTiles: ParticleTile[];       // includes opacity
+}
+```
+
+Important: a column may appear in more than one layer during transition. For example, near `fidelity = 0.7`, it may have both block cells and a mid-detail proxy so the layers can crossfade.
+
+## Block opacity support
+
+The current `WorldRenderer` renders block components as fully opaque. Add a procedural high-detail renderer path that accepts opacity:
+
+```text
+src/adapters/three/procedural-high-detail-renderer.tsx
+```
+
+Initial implementation can group cells by opacity/material and pass opacity into materials. Longer term, use instancing with per-instance opacity or dithered fade.
+
+Recommended first step:
+
+- keep static `WorldRenderer` unchanged,
+- add procedural renderer for snapshot high-detail cells,
+- for `opacity < 1`, use transparent material or alpha-tested dither to avoid sorting artifacts.
+
+## Wireframe fade support
+
+Wire geometry needs per-vertex attributes:
+
+```ts
+attribute float fidelity;
+attribute float lodOpacity;
+attribute float transitionProgress;
+```
+
+Shader opacity:
+
+```glsl
+float opacity = baseOpacity * lodOpacity * cameraFade * transitionProgress;
+```
+
+## Mid-detail proxy support
+
+Mid-detail terrain columns should bridge between blocks and wireframes:
+
+- simplified column sides and top surface,
+- biome/surface color or low-cost material,
+- transparent fade in/out,
+- no collision authority.
+
+Without this layer, block-to-wire crossfade will still feel abrupt because wireframes have very different visual density.
+
+## Implementation order
+
+1. Add column-distance LOD sampling with continuous fidelity.
+2. Extend render snapshot with opacity for high/mid/wire/particle layers.
+3. Add transition state/hysteresis in `ProceduralWorldRuntime`.
+4. Add procedural high-detail renderer that accepts block opacity.
+5. Add mid-detail column renderer.
+6. Update fringe geometry/shader to use snapshot opacity and fidelity.
+7. Stop rendering procedural terrain through the old hard-cut `WorldRenderer` path except for static mode.
+
+## Tests
+
+Add tests for:
+
+- opacity curves are monotonic where expected,
+- blocks and wireframes overlap during transition instead of hard switching,
+- hysteresis prevents repeated LOD flips near thresholds,
+- snapshot includes both old and new layers during transition windows,
+- seed preview blocks remain fully opaque.
+
+## Acceptance criteria
+
+- Walking forward does not cause blocks to pop into existence.
+- Walking backward does not cause blocks to disappear instantly.
+- Wireframes fade down as blocks/mid-detail terrain fade up.
+- The transition is driven by one shared LOD/fidelity policy.
+- Static rendering behavior remains unchanged.

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,21 +2,6 @@ import type { AppProps } from "next/app";
 import Head from "next/head";
 import "../styles/shadcn.css";
 import "../styles/global.scss";
-import clsx from "clsx";
-import { Noto_Sans_Mono, Open_Sans, Roboto_Slab } from "next/font/google";
-
-const openSans = Open_Sans({
-  subsets: ["latin"],
-  variable: "--font-open-sans",
-});
-const notoSansMono = Noto_Sans_Mono({
-  subsets: ["latin"],
-  variable: "--font-noto-sans-mono",
-});
-const robotoSlab = Roboto_Slab({
-  subsets: ["latin"],
-  variable: "--font-roboto-slab",
-});
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -24,14 +9,7 @@ function MyApp({ Component, pageProps }: AppProps) {
       <Head>
         <title>Gram Liu</title>
       </Head>
-      <main
-        className={clsx(
-          openSans.variable,
-          notoSansMono.variable,
-          robotoSlab.variable,
-          "font-sans"
-        )}
-      >
+      <main className="font-sans">
         <Component {...pageProps} />
       </main>
     </>

--- a/pages/library.tsx
+++ b/pages/library.tsx
@@ -3,7 +3,7 @@ import Bookshelf from "../src/components/Bookshelf";
 import Layout from "../src/components/Layout";
 import NavPill from "../src/components/NavPill";
 import Papers from "../src/components/Papers";
-import getBooks, { type Book } from "../src/server/getBooks";
+import getBooks, { type Book, getFallbackBooks } from "../src/server/getBooks";
 import getPapers, { type ResearchPaper } from "../src/server/getPapers";
 
 export default function BookshelfPage({
@@ -23,10 +23,28 @@ export default function BookshelfPage({
   );
 }
 
+async function resolveLibraryData<T>(
+  label: string,
+  loader: () => Promise<T>,
+  fallback: T
+): Promise<T> {
+  try {
+    return await loader();
+  } catch (error) {
+    console.error(
+      `Failed to load ${label}; rendering /library with fallback data.`,
+      error
+    );
+    return fallback;
+  }
+}
+
 export async function getStaticProps() {
   const start = Date.now();
-  const [books, papers] = await Promise.all([getBooks(), getPapers()]);
-  console.log(books);
+  const [books, papers] = await Promise.all([
+    resolveLibraryData("books", getBooks, getFallbackBooks()),
+    resolveLibraryData("papers", getPapers, []),
+  ]);
   const end = Date.now();
   console.log(`getStaticProps took ${end - start}ms`);
 

--- a/pages/world.tsx
+++ b/pages/world.tsx
@@ -1,9 +1,6 @@
 import clsx from "clsx";
-import { Inter } from "next/font/google";
 import { useEffect, useState } from "react";
 import World from "../src/components/world";
-
-const inter = Inter({ subsets: ["latin"] });
 
 type MobileControlKey = "KeyW" | "KeyA" | "KeyS" | "KeyD";
 
@@ -85,7 +82,7 @@ export default function WorldPage() {
   const [isPlaying, setIsPlaying] = useState(false);
 
   return (
-    <main className={`flex h-screen w-screen ${inter.className} relative`}>
+    <main className="relative flex h-screen w-screen font-sans">
       <World
         rotateWorld={false}
         interactiveMode={isPlaying}

--- a/pages/world.tsx
+++ b/pages/world.tsx
@@ -1,20 +1,102 @@
 import clsx from "clsx";
 import { Inter } from "next/font/google";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import World from "../src/components/world";
 
 const inter = Inter({ subsets: ["latin"] });
+
+type MobileControlKey = "KeyW" | "KeyA" | "KeyS" | "KeyD";
+
+interface MobileControlButton {
+  code: MobileControlKey;
+  label: string;
+  gridArea: string;
+}
+
+const mobileControls: MobileControlButton[] = [
+  { code: "KeyW", label: "W", gridArea: "col-start-2 row-start-1" },
+  { code: "KeyA", label: "A", gridArea: "col-start-1 row-start-2" },
+  { code: "KeyS", label: "S", gridArea: "col-start-2 row-start-2" },
+  { code: "KeyD", label: "D", gridArea: "col-start-3 row-start-2" },
+];
+
+function dispatchKeyboardControl(
+  code: MobileControlKey,
+  type: "keydown" | "keyup"
+) {
+  window.dispatchEvent(
+    new KeyboardEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      code,
+      key: code.replace("Key", "").toLowerCase(),
+    })
+  );
+}
+
+function MobileWasdControls({ enabled }: { enabled: boolean }) {
+  useEffect(() => {
+    if (!enabled) {
+      for (const control of mobileControls) {
+        dispatchKeyboardControl(control.code, "keyup");
+      }
+    }
+  }, [enabled]);
+
+  return (
+    <div
+      className={clsx(
+        "absolute bottom-24 left-4 z-20 grid grid-cols-3 grid-rows-2 gap-2 md:hidden select-none touch-none transition-opacity",
+        enabled ? "opacity-100" : "pointer-events-none opacity-40"
+      )}
+      role="group"
+      aria-label="Mobile WASD controls"
+    >
+      {mobileControls.map((control) => (
+        <button
+          key={control.code}
+          type="button"
+          aria-label={`Move ${control.label}`}
+          disabled={!enabled}
+          onPointerDown={(event) => {
+            event.preventDefault();
+            event.currentTarget.setPointerCapture(event.pointerId);
+            dispatchKeyboardControl(control.code, "keydown");
+          }}
+          onPointerUp={(event) => {
+            event.preventDefault();
+            dispatchKeyboardControl(control.code, "keyup");
+          }}
+          onPointerCancel={() => dispatchKeyboardControl(control.code, "keyup")}
+          onPointerLeave={() => dispatchKeyboardControl(control.code, "keyup")}
+          className={clsx(
+            control.gridArea,
+            "h-14 w-14 rounded-full border border-white/40 bg-black/70 text-lg font-bold text-white shadow-lg backdrop-blur-sm active:scale-95 disabled:cursor-not-allowed"
+          )}
+        >
+          {control.label}
+        </button>
+      ))}
+    </div>
+  );
+}
 
 export default function WorldPage() {
   const [isPlaying, setIsPlaying] = useState(false);
 
   return (
     <main className={`flex h-screen w-screen ${inter.className} relative`}>
-      <World rotateWorld={false} interactiveMode={isPlaying} showFringe />
+      <World
+        rotateWorld={false}
+        interactiveMode={isPlaying}
+        showFringe
+        worldMode="procedural"
+      />
+      <MobileWasdControls enabled={isPlaying} />
       <button
         onClick={() => setIsPlaying(!isPlaying)}
         className={clsx(
-          "absolute bottom-8 left-1/2 -translate-x-1/2 px-4 py-2 bg-yellow-500 text-black rounded-lg shadow-lg hover:bg-yellow-600 transition-all",
+          "absolute bottom-8 left-1/2 z-20 -translate-x-1/2 px-4 py-2 bg-yellow-500 text-black rounded-lg shadow-lg hover:bg-yellow-600 transition-all",
           {
             "animate-bounce": !isPlaying,
           }

--- a/src/adapters/three/procedural-mid-detail-renderer.tsx
+++ b/src/adapters/three/procedural-mid-detail-renderer.tsx
@@ -1,0 +1,48 @@
+import type { MidDetailColumn } from "../../game/world/procedural/render-snapshot";
+
+interface Props {
+  columns: MidDetailColumn[];
+}
+
+function colorForBlockId(blockId: number): string {
+  switch (blockId) {
+    case 2:
+      return "#6aa84f";
+    case 3:
+      return "#7a5634";
+    case 9:
+      return "#4c8fbd";
+    case 12:
+      return "#d8c98f";
+    default:
+      return "#8a8a8a";
+  }
+}
+
+export default function ProceduralMidDetailRenderer({ columns }: Props) {
+  return (
+    <>
+      {columns.map((column) => {
+        const height = Math.max(1, column.height - column.y + 1);
+        return (
+          <mesh
+            key={`${column.x}-${column.z}`}
+            position={[column.x + 0.5, column.y + height / 2, column.z + 0.5]}
+            scale={[1, height, 1]}
+            receiveShadow
+          >
+            <boxGeometry args={[1, 1, 1]} />
+            <meshStandardMaterial
+              color={colorForBlockId(column.surfaceBlockId)}
+              opacity={column.opacity * 0.55}
+              transparent
+              depthWrite={false}
+              roughness={1}
+              metalness={0}
+            />
+          </mesh>
+        );
+      })}
+    </>
+  );
+}

--- a/src/adapters/three/world-renderer.tsx
+++ b/src/adapters/three/world-renderer.tsx
@@ -39,6 +39,10 @@ export default function WorldRenderer({
   return (
     <>
       {renderedCells.map((cell) => {
+        if (cell.opacity !== undefined && cell.opacity <= 0.01) {
+          return null;
+        }
+
         const block = getBlockDefinition(cell.id);
         const texture = getRenderableBlockTextures(block.renderKey);
 

--- a/src/adapters/three/world-renderer.tsx
+++ b/src/adapters/three/world-renderer.tsx
@@ -1,10 +1,19 @@
 import Block from "../../components/world/block";
 import { getRenderableBlockTextures } from "../../components/world/blocks";
 import { getBlockDefinition } from "../../game/world/block-registry";
-import type { VoxelWorld } from "../../game/world/world";
+import type { LoadedWorldCell } from "../../game/world/world-loader";
+import type { RenderableWorldQuery } from "../../game/world/world-query";
+
+export type WorldRenderDetail = "full" | "preview";
+
+export interface RenderableCellWithOpacity extends LoadedWorldCell {
+  opacity?: number;
+}
 
 interface Props {
-  world: VoxelWorld;
+  world: RenderableWorldQuery;
+  detail?: WorldRenderDetail;
+  cells?: RenderableCellWithOpacity[];
 }
 
 const emptyFluidAdjacency = {
@@ -16,10 +25,20 @@ const emptyFluidAdjacency = {
   west: false,
 };
 
-export default function WorldRenderer({ world }: Props) {
+export default function WorldRenderer({
+  world,
+  detail = "full",
+  cells,
+}: Props) {
+  const renderedCells: RenderableCellWithOpacity[] =
+    cells ??
+    (detail === "preview"
+      ? world.getExposedRenderableCells()
+      : world.getRenderableCells());
+
   return (
     <>
-      {world.getRenderableCells().map((cell) => {
+      {renderedCells.map((cell) => {
         const block = getBlockDefinition(cell.id);
         const texture = getRenderableBlockTextures(block.renderKey);
 
@@ -33,6 +52,7 @@ export default function WorldRenderer({ world }: Props) {
             position={[cell.x, cell.y, cell.z]}
             texture={texture}
             id={cell.id}
+            opacity={cell.opacity}
             adjacentBlocks={
               block.renderKey === "water"
                 ? world.getFluidAdjacency(cell.x, cell.y, cell.z)

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -111,6 +111,7 @@ export default function Hero() {
               interactiveMode={isPlaying}
               closeUp
               showFringe={isDesktop}
+              worldMode="procedural"
             />
           </div>
           <div className="hidden md:flex flex-col justify-start items-center text-center gap-5 pt-32">

--- a/src/components/world/block.tsx
+++ b/src/components/world/block.tsx
@@ -14,6 +14,7 @@ export interface BlockProps extends CommonProps {
   };
   id: number;
   adjacentBlocks: WaterBlockAdjacency;
+  opacity?: number;
 }
 
 export default function Block({
@@ -23,10 +24,21 @@ export default function Block({
   texture: { top, side },
   id,
   adjacentBlocks,
+  opacity = 1,
 }: BlockProps) {
   const isWater = id === 9;
-  const topTexture = useTextureMaterial(top);
-  const sideTexture = useTextureMaterial(side);
+  const renderedTop = {
+    ...top,
+    translucent: top.translucent || opacity < 1,
+    opacity: (top.opacity ?? 1) * opacity,
+  };
+  const renderedSide = {
+    ...side,
+    translucent: side.translucent || opacity < 1,
+    opacity: (side.opacity ?? 1) * opacity,
+  };
+  const topTexture = useTextureMaterial(renderedTop);
+  const sideTexture = useTextureMaterial(renderedSide);
   const meshRef = useRef<Mesh>(null);
 
   // Function to determine if a face should be rendered
@@ -40,7 +52,7 @@ export default function Block({
       <mesh
         ref={meshRef}
         position={[0.5, 0.5, 0.5]}
-        castShadow
+        castShadow={opacity >= 0.95}
         receiveShadow
         material={
           [

--- a/src/components/world/fringe/fringe-layout.ts
+++ b/src/components/world/fringe/fringe-layout.ts
@@ -1,5 +1,5 @@
 import type { WorldBounds } from "../../../game/core/types";
-import type { VoxelWorld } from "../../../game/world/world";
+import type { RenderableWorldQuery } from "../../../game/world/world-query";
 import { computeOutwardVector } from "./fringe-animation";
 
 export interface FringeWireframe {
@@ -7,6 +7,8 @@ export interface FringeWireframe {
   y: number;
   z: number;
   opacity: number;
+  fidelity?: number;
+  distanceBand?: number;
 }
 
 export interface FringeGridTile {
@@ -16,6 +18,8 @@ export interface FringeGridTile {
   row: number;
   outward: [number, number];
   emissionWeight: number;
+  fidelity?: number;
+  distanceBand?: number;
 }
 
 export interface FringeFocus {
@@ -79,7 +83,7 @@ interface EdgeFringeConfig {
 }
 
 function getHighestGrassY(
-  world: VoxelWorld,
+  world: RenderableWorldQuery,
   x: number,
   z: number
 ): number | null {
@@ -94,7 +98,7 @@ function getHighestGrassY(
 }
 
 function getHighestSolidExcludingLeaves(
-  world: VoxelWorld,
+  world: RenderableWorldQuery,
   x: number,
   z: number
 ): number | null {
@@ -115,7 +119,7 @@ function getHighestSolidExcludingLeaves(
 }
 
 function getColumnTopY(
-  world: VoxelWorld,
+  world: RenderableWorldQuery,
   x: number,
   z: number,
   useGrassHeight: boolean
@@ -195,7 +199,7 @@ function addGridTile(
 }
 
 function addEdgeFringe(
-  world: VoxelWorld,
+  world: RenderableWorldQuery,
   wireframes: Map<string, FringeWireframe>,
   gridTiles: Map<string, FringeGridTile>,
   config: EdgeFringeConfig,
@@ -280,7 +284,7 @@ function addCornerFringe(
   }
 }
 
-export function computeFringeLayout(world: VoxelWorld): FringeLayout {
+export function computeFringeLayout(world: RenderableWorldQuery): FringeLayout {
   const bounds = world.getBounds();
   const centerX = (bounds.min.x + bounds.max.x + 1) / 2;
   const centerZ = (bounds.min.z + bounds.max.z + 1) / 2;

--- a/src/components/world/fringe/fringe-line-field.tsx
+++ b/src/components/world/fringe/fringe-line-field.tsx
@@ -11,13 +11,19 @@ interface Props {
 const lineVertexShader = `
   attribute float baseOpacity;
   attribute float lineKind;
+  attribute float fidelity;
+  attribute float lodOpacity;
   varying float vBaseOpacity;
   varying float vLineKind;
+  varying float vFidelity;
+  varying float vLodOpacity;
   varying vec3 vWorldPos;
 
   void main() {
     vBaseOpacity = baseOpacity;
     vLineKind = lineKind;
+    vFidelity = fidelity;
+    vLodOpacity = lodOpacity;
     vWorldPos = (modelMatrix * vec4(position, 1.0)).xyz;
     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
   }
@@ -35,6 +41,8 @@ const lineFragmentShader = `
 
   varying float vBaseOpacity;
   varying float vLineKind;
+  varying float vFidelity;
+  varying float vLodOpacity;
   varying vec3 vWorldPos;
 
   void main() {
@@ -54,7 +62,8 @@ const lineFragmentShader = `
     float lateralOuter = mix(uWireframeLateralOuter, uLateralOuter, vLineKind);
     float lateralFade = 1.0 - smoothstep(lateralInner, lateralOuter, lateralDist);
 
-    float opacity = vBaseOpacity * backFade * lateralFade;
+    float fidelityPulse = mix(1.0, 0.82 + 0.18 * vFidelity, 1.0 - vLineKind);
+    float opacity = vBaseOpacity * vLodOpacity * fidelityPulse * backFade * lateralFade;
     if (opacity < 0.001) {
       discard;
     }

--- a/src/components/world/fringe/fringe-line-geometry.test.ts
+++ b/src/components/world/fringe/fringe-line-geometry.test.ts
@@ -26,6 +26,8 @@ describe("buildFringeLineGeometry", () => {
     expect(positions.count).toBe(expectedVertexCount);
     expect(baseOpacity.count).toBe(expectedVertexCount);
     expect(geometry.getAttribute("lineKind").count).toBe(expectedVertexCount);
+    expect(geometry.getAttribute("fidelity").count).toBe(expectedVertexCount);
+    expect(geometry.getAttribute("lodOpacity").count).toBe(expectedVertexCount);
   });
 
   it("tags wireframe vertices as kind 0 and grid vertices as kind 1", () => {

--- a/src/components/world/fringe/fringe-line-geometry.ts
+++ b/src/components/world/fringe/fringe-line-geometry.ts
@@ -22,10 +22,14 @@ function appendWireframeBlock(
   positions: number[],
   opacities: number[],
   lineKinds: number[],
+  fidelities: number[],
+  lodOpacities: number[],
   x: number,
   y: number,
   z: number,
-  opacity: number
+  opacity: number,
+  fidelity = 0,
+  lodOpacity = 1
 ): void {
   const ox = x + 0.5;
   const oy = y + 0.5;
@@ -39,6 +43,8 @@ function appendWireframeBlock(
     );
     opacities.push(opacity);
     lineKinds.push(0);
+    fidelities.push(fidelity);
+    lodOpacities.push(lodOpacity);
   }
 }
 
@@ -46,10 +52,14 @@ function appendGridTile(
   positions: number[],
   opacities: number[],
   lineKinds: number[],
+  fidelities: number[],
+  lodOpacities: number[],
   x: number,
   y: number,
   z: number,
-  opacity: number
+  opacity: number,
+  fidelity = 0,
+  lodOpacity = 1
 ): void {
   for (let i = 0; i < gridTileVertices.length; i += 3) {
     positions.push(
@@ -59,6 +69,8 @@ function appendGridTile(
     );
     opacities.push(opacity);
     lineKinds.push(1);
+    fidelities.push(fidelity);
+    lodOpacities.push(lodOpacity);
   }
 }
 
@@ -74,20 +86,36 @@ export function buildFringeLineGeometry(layout: FringeLayout): BufferGeometry {
   const positions: number[] = [];
   const opacities: number[] = [];
   const lineKinds: number[] = [];
+  const fidelities: number[] = [];
+  const lodOpacities: number[] = [];
 
-  for (const { x, y, z, opacity } of layout.wireframes) {
-    appendWireframeBlock(positions, opacities, lineKinds, x, y, z, opacity);
+  for (const { x, y, z, opacity, fidelity } of layout.wireframes) {
+    appendWireframeBlock(
+      positions,
+      opacities,
+      lineKinds,
+      fidelities,
+      lodOpacities,
+      x,
+      y,
+      z,
+      opacity,
+      fidelity ?? 0
+    );
   }
 
-  for (const { x, z, opacity } of layout.gridTiles) {
+  for (const { x, z, opacity, fidelity } of layout.gridTiles) {
     appendGridTile(
       positions,
       opacities,
       lineKinds,
+      fidelities,
+      lodOpacities,
       x,
       layout.gridY,
       z,
-      opacity
+      opacity,
+      fidelity ?? 0
     );
   }
 
@@ -103,6 +131,14 @@ export function buildFringeLineGeometry(layout: FringeLayout): BufferGeometry {
   geometry.setAttribute(
     "lineKind",
     new BufferAttribute(new Float32Array(lineKinds), 1)
+  );
+  geometry.setAttribute(
+    "fidelity",
+    new BufferAttribute(new Float32Array(fidelities), 1)
+  );
+  geometry.setAttribute(
+    "lodOpacity",
+    new BufferAttribute(new Float32Array(lodOpacities), 1)
   );
 
   return geometry;

--- a/src/components/world/fringe/fringe-renderer.tsx
+++ b/src/components/world/fringe/fringe-renderer.tsx
@@ -1,15 +1,31 @@
 import { useMemo } from "react";
-import type { VoxelWorld } from "../../../game/world/world";
+import type { ProceduralRenderSnapshot } from "../../../game/world/procedural/render-snapshot";
+import type { RenderableWorldQuery } from "../../../game/world/world-query";
 import { computeFringeLayout, FRINGE_CONFIG } from "./fringe-layout";
 import FringeLineField from "./fringe-line-field";
 import FringeParticleField from "./fringe-particles";
+import { computeProceduralFringeLayout } from "./procedural-fringe-layout";
 
 interface Props {
-  world: VoxelWorld;
+  world: RenderableWorldQuery;
+  enableParticles?: boolean;
+  procedural?: boolean;
+  snapshot?: ProceduralRenderSnapshot | null;
 }
 
-export default function FringeRenderer({ world }: Props) {
-  const layout = useMemo(() => computeFringeLayout(world), [world]);
+export default function FringeRenderer({
+  world,
+  enableParticles = true,
+  procedural = false,
+  snapshot = null,
+}: Props) {
+  const layout = useMemo(
+    () =>
+      procedural
+        ? computeProceduralFringeLayout(world, snapshot)
+        : computeFringeLayout(world),
+    [world, procedural, snapshot]
+  );
   const particleTiles = useMemo(
     () =>
       layout.gridTiles.filter(
@@ -20,11 +36,13 @@ export default function FringeRenderer({ world }: Props) {
   return (
     <>
       <FringeLineField layout={layout} />
-      <FringeParticleField
-        tiles={particleTiles}
-        y={layout.gridY}
-        focus={layout.focus}
-      />
+      {enableParticles ? (
+        <FringeParticleField
+          tiles={particleTiles}
+          y={layout.gridY}
+          focus={layout.focus}
+        />
+      ) : null}
     </>
   );
 }

--- a/src/components/world/fringe/procedural-fringe-layout.test.ts
+++ b/src/components/world/fringe/procedural-fringe-layout.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { FULL_DETAIL_SIZE_XZ } from "../../../game/world/procedural/lod-policy";
+import { ProceduralWorldRuntime } from "../../../game/world/procedural/procedural-runtime";
+import { ProceduralVoxelWorld } from "../../../game/world/procedural/procedural-world";
+import { computeProceduralFringeLayout } from "./procedural-fringe-layout";
+
+describe("computeProceduralFringeLayout", () => {
+  it("starts wireframes immediately outside the 10x10 rendered footprint", () => {
+    const world = new ProceduralVoxelWorld({ seed: 23, mode: "preview" });
+    const bounds = world.getBounds();
+    const layout = computeProceduralFringeLayout(world);
+    const wireframeXs = new Set(
+      layout.wireframes.map((wireframe) => wireframe.x)
+    );
+    const wireframeZs = new Set(
+      layout.wireframes.map((wireframe) => wireframe.z)
+    );
+
+    expect(bounds.max.x - bounds.min.x + 1).toBe(FULL_DETAIL_SIZE_XZ);
+    expect(bounds.max.z - bounds.min.z + 1).toBe(FULL_DETAIL_SIZE_XZ);
+    expect(wireframeXs.has(bounds.min.x - 1)).toBe(true);
+    expect(wireframeXs.has(bounds.max.x + 1)).toBe(true);
+    expect(wireframeZs.has(bounds.min.z - 1)).toBe(true);
+    expect(wireframeZs.has(bounds.max.z + 1)).toBe(true);
+  });
+
+  it("uses snapshot bands so procedural wireframes shift with focus", () => {
+    const runtime = new ProceduralWorldRuntime({
+      seed: 23,
+      mode: "interactive",
+      previewCenterX: 5,
+      previewCenterZ: 5,
+    });
+
+    runtime.updateFocus({ x: 5, y: 0, z: 5 }, "interactive");
+    const firstLayout = computeProceduralFringeLayout(
+      runtime.world,
+      runtime.createSnapshot()
+    );
+
+    runtime.updateFocus({ x: 20, y: 0, z: 5 }, "interactive");
+    const secondLayout = computeProceduralFringeLayout(
+      runtime.world,
+      runtime.createSnapshot()
+    );
+
+    const firstMinX = Math.min(...firstLayout.wireframes.map((wire) => wire.x));
+    const secondMinX = Math.min(
+      ...secondLayout.wireframes.map((wire) => wire.x)
+    );
+
+    expect(secondMinX).toBeGreaterThan(firstMinX);
+  });
+});

--- a/src/components/world/fringe/procedural-fringe-layout.test.ts
+++ b/src/components/world/fringe/procedural-fringe-layout.test.ts
@@ -4,6 +4,26 @@ import { ProceduralWorldRuntime } from "../../../game/world/procedural/procedura
 import { ProceduralVoxelWorld } from "../../../game/world/procedural/procedural-world";
 import { computeProceduralFringeLayout } from "./procedural-fringe-layout";
 
+function distanceFromBounds(
+  x: number,
+  z: number,
+  bounds: { min: { x: number; z: number }; max: { x: number; z: number } }
+): number {
+  const dx =
+    x < bounds.min.x
+      ? bounds.min.x - x
+      : x > bounds.max.x
+        ? x - bounds.max.x
+        : 0;
+  const dz =
+    z < bounds.min.z
+      ? bounds.min.z - z
+      : z > bounds.max.z
+        ? z - bounds.max.z
+        : 0;
+  return Math.max(dx, dz);
+}
+
 describe("computeProceduralFringeLayout", () => {
   it("starts wireframes immediately outside the 10x10 rendered footprint", () => {
     const world = new ProceduralVoxelWorld({ seed: 23, mode: "preview" });
@@ -50,5 +70,27 @@ describe("computeProceduralFringeLayout", () => {
     );
 
     expect(secondMinX).toBeGreaterThan(firstMinX);
+  });
+
+  it("keeps snapshot wireframes within two blocks of the rendered footprint", () => {
+    const runtime = new ProceduralWorldRuntime({
+      seed: 23,
+      mode: "interactive",
+      previewCenterX: 5,
+      previewCenterZ: 5,
+    });
+
+    runtime.updateFocus({ x: 5, y: 0, z: 5 }, "interactive");
+    const snapshot = runtime.createSnapshot();
+    const layout = computeProceduralFringeLayout(runtime.world, snapshot);
+
+    expect(layout.wireframes.length).toBeGreaterThan(0);
+    expect(
+      Math.max(
+        ...layout.wireframes.map((wire) =>
+          distanceFromBounds(wire.x, wire.z, snapshot.fullDetailBounds)
+        )
+      )
+    ).toBeLessThanOrEqual(2);
   });
 });

--- a/src/components/world/fringe/procedural-fringe-layout.ts
+++ b/src/components/world/fringe/procedural-fringe-layout.ts
@@ -1,0 +1,172 @@
+import type { ProceduralRenderSnapshot } from "../../../game/world/procedural/render-snapshot";
+import type { RenderableWorldQuery } from "../../../game/world/world-query";
+import { computeOutwardVector } from "./fringe-animation";
+import {
+  FRINGE_CONFIG,
+  type FringeGridTile,
+  type FringeLayout,
+  type FringeWireframe,
+} from "./fringe-layout";
+
+function cellKey(x: number, y: number, z: number): string {
+  return `${x},${y},${z}`;
+}
+
+function gridOpacityForRow(row: number): number {
+  return (
+    FRINGE_CONFIG.gridOpacityByRow[row - 1] ??
+    FRINGE_CONFIG.gridOpacityByRow.at(-1) ??
+    0.2
+  );
+}
+
+function addWireColumn(
+  wireframes: Map<string, FringeWireframe>,
+  world: RenderableWorldQuery,
+  x: number,
+  z: number,
+  opacity: number
+): void {
+  const topY = world.getHighestSolidCell(x, z);
+  if (topY === null) {
+    return;
+  }
+
+  const maxY = Math.max(0, topY - 1);
+  for (let y = 0; y <= maxY; y++) {
+    wireframes.set(cellKey(x, y, z), { x, y, z, opacity });
+  }
+}
+
+function addGridTile(
+  gridTiles: Map<string, FringeGridTile>,
+  x: number,
+  z: number,
+  row: number,
+  centerX: number,
+  centerZ: number
+): void {
+  const opacity = gridOpacityForRow(row);
+  if (opacity < FRINGE_CONFIG.minOpacity) {
+    return;
+  }
+
+  gridTiles.set(`${x},${z}`, {
+    x,
+    z,
+    opacity,
+    row,
+    outward: computeOutwardVector(x, z, centerX, centerZ),
+    emissionWeight: opacity,
+  });
+}
+
+function computeSnapshotFringeLayout(
+  snapshot: ProceduralRenderSnapshot
+): FringeLayout {
+  const wireframes: FringeWireframe[] = [];
+  const gridTiles: FringeGridTile[] = [];
+
+  for (const column of snapshot.wireColumns) {
+    if (column.opacity < FRINGE_CONFIG.minOpacity) {
+      continue;
+    }
+
+    for (let y = column.minY; y <= column.maxY; y++) {
+      wireframes.push({
+        x: column.x,
+        y,
+        z: column.z,
+        opacity: column.opacity,
+        fidelity: column.fidelity,
+        distanceBand: column.distanceBand,
+      });
+    }
+  }
+
+  for (const tile of snapshot.gridTiles) {
+    if (tile.opacity < FRINGE_CONFIG.minOpacity) {
+      continue;
+    }
+
+    gridTiles.push({
+      x: tile.x,
+      z: tile.z,
+      opacity: tile.opacity,
+      row: tile.row,
+      outward: computeOutwardVector(
+        tile.x,
+        tile.z,
+        snapshot.focus.x,
+        snapshot.focus.z
+      ),
+      emissionWeight: tile.emissionWeight,
+      fidelity: tile.fidelity,
+      distanceBand: tile.row,
+    });
+  }
+
+  return {
+    wireframes,
+    gridTiles,
+    gridY: FRINGE_CONFIG.gridY,
+    focus: snapshot.focus,
+  };
+}
+
+export function computeProceduralFringeLayout(
+  world: RenderableWorldQuery,
+  snapshot?: ProceduralRenderSnapshot | null
+): FringeLayout {
+  if (snapshot) {
+    return computeSnapshotFringeLayout(snapshot);
+  }
+
+  const bounds = world.getBounds();
+  const centerX = (bounds.min.x + bounds.max.x) / 2;
+  const centerZ = (bounds.min.z + bounds.max.z) / 2;
+  const minX = bounds.min.x;
+  const maxX = bounds.max.x;
+  const minZ = bounds.min.z;
+  const maxZ = bounds.max.z;
+  const wireMinX = minX - 1;
+  const wireMaxX = maxX + 1;
+  const wireMinZ = minZ - 1;
+  const wireMaxZ = maxZ + 1;
+  const wireframes = new Map<string, FringeWireframe>();
+  const gridTiles = new Map<string, FringeGridTile>();
+
+  for (let x = wireMinX; x <= wireMaxX; x++) {
+    addWireColumn(wireframes, world, x, wireMinZ, 0.9);
+    addWireColumn(wireframes, world, x, wireMaxZ, 0.9);
+  }
+
+  for (let z = wireMinZ; z <= wireMaxZ; z++) {
+    addWireColumn(wireframes, world, wireMinX, z, 0.9);
+    addWireColumn(wireframes, world, wireMaxX, z, 0.9);
+  }
+
+  for (let row = 1; row <= FRINGE_CONFIG.gridRows; row++) {
+    const gridMinX = wireMinX - row;
+    const gridMaxX = wireMaxX + row;
+    const gridMinZ = wireMinZ - row;
+    const gridMaxZ = wireMaxZ + row;
+
+    for (let x = gridMinX; x <= gridMaxX; x++) {
+      addGridTile(gridTiles, x, gridMinZ, row, centerX, centerZ);
+      addGridTile(gridTiles, x, gridMaxZ, row, centerX, centerZ);
+    }
+
+    for (let z = gridMinZ; z <= gridMaxZ; z++) {
+      addGridTile(gridTiles, gridMinX, z, row, centerX, centerZ);
+      addGridTile(gridTiles, gridMaxX, z, row, centerX, centerZ);
+    }
+  }
+
+  return {
+    wireframes: Array.from(wireframes.values()),
+    gridTiles: Array.from(gridTiles.values()),
+    gridY: FRINGE_CONFIG.gridY,
+    focus: { x: centerX, y: 0, z: centerZ },
+  };
+}

--- a/src/components/world/index.tsx
+++ b/src/components/world/index.tsx
@@ -1,6 +1,6 @@
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
-import Map from "./map";
+import Map, { type WorldMode } from "./map";
 
 interface Props {
   size?: number;
@@ -8,6 +8,7 @@ interface Props {
   interactiveMode?: boolean;
   closeUp?: boolean;
   showFringe?: boolean;
+  worldMode?: WorldMode;
 }
 
 function World({
@@ -16,6 +17,7 @@ function World({
   interactiveMode = false,
   closeUp = false,
   showFringe = false,
+  worldMode = "static",
 }: Props) {
   return (
     <Canvas
@@ -26,13 +28,13 @@ function World({
       style={{
         height: closeUp ? "900px" : "100%",
       }}
-      shadows
+      shadows={interactiveMode}
     >
       <ambientLight intensity={0.5} />
       <directionalLight
         position={[1, 10, 5]}
         intensity={1}
-        castShadow
+        castShadow={interactiveMode}
         shadow-mapSize-width={1024}
         shadow-mapSize-height={1024}
         shadow-camera-near={0.5}
@@ -54,6 +56,7 @@ function World({
         rotateWorld={rotateWorld}
         interactiveMode={interactiveMode}
         showFringe={showFringe}
+        worldMode={worldMode}
       />
     </Canvas>
   );

--- a/src/components/world/map.tsx
+++ b/src/components/world/map.tsx
@@ -1,30 +1,30 @@
 import { useFrame } from "@react-three/fiber";
 import { useEffect, useRef } from "react";
-import type { Group } from "three";
+import { type Group, Vector3 } from "three";
 import { useKeyboardState } from "../../adapters/input/keyboard";
+import ProceduralMidDetailRenderer from "../../adapters/three/procedural-mid-detail-renderer";
 import WorldRenderer from "../../adapters/three/world-renderer";
-import { vec3 } from "../../game/core/math/vec3";
 import { createGameState, type GameState } from "../../game/game";
-import { VoxelWorld } from "../../game/world/world";
-import { loadWorldCellsFromString } from "../../game/world/world-loader";
 import FringeRenderer from "./fringe/fringe-renderer";
 import Player from "./player";
-import worldData from "./world-data";
+import PlayerCameraFollow from "./player-camera-follow";
+import {
+  DEFAULT_PLAYER_ROTATION,
+  DEFAULT_WORLD_ROTATION,
+  useWorldRuntime,
+  type WorldMode,
+} from "./use-world-runtime";
 
-const world = new VoxelWorld(loadWorldCellsFromString(worldData));
 const ROTATION_SPEED = 0.3;
 
-type Vec3 = [number, number, number];
-const DEFAULT_PLAYER_POSITION: Vec3 = [9, 6, 1];
-const DEFAULT_PLAYER_STATE_POSITION = vec3(9.5, 6, 1.5);
-const DEFAULT_PLAYER_ROTATION: Vec3 = [0, 0, 0];
-const DEFAULT_WORLD_ROTATION: Vec3 = [0, 0, 0];
+export type { WorldMode } from "./use-world-runtime";
 
 interface Props {
   size?: number;
   rotateWorld?: boolean;
   interactiveMode?: boolean;
   showFringe?: boolean;
+  worldMode?: WorldMode;
 }
 
 /**
@@ -35,25 +35,33 @@ export default function Map({
   rotateWorld,
   interactiveMode = false,
   showFringe = false,
+  worldMode = "static",
 }: Props) {
   const playerRef = useRef<Group>(null);
   const worldRef = useRef<Group>(null);
   const keyControlsRef = useKeyboardState();
+  const {
+    activeWorld,
+    isProcedural,
+    runtimeMode,
+    updateFocus,
+    renderSnapshot,
+    playerPosition,
+    playerStatePosition,
+  } = useWorldRuntime({ worldMode, interactiveMode });
   const gameStateRef = useRef<GameState>(
-    createGameState(world, DEFAULT_PLAYER_STATE_POSITION)
+    createGameState(activeWorld, playerStatePosition)
   );
 
   function resetPlayer() {
-    gameStateRef.current = createGameState(
-      world,
-      DEFAULT_PLAYER_STATE_POSITION
-    );
+    gameStateRef.current = createGameState(activeWorld, playerStatePosition);
+    updateFocus(playerStatePosition);
 
     if (playerRef.current) {
       playerRef.current.position.set(
-        DEFAULT_PLAYER_STATE_POSITION.x,
-        DEFAULT_PLAYER_STATE_POSITION.y,
-        DEFAULT_PLAYER_STATE_POSITION.z
+        playerStatePosition.x,
+        playerStatePosition.y,
+        playerStatePosition.z
       );
       playerRef.current.rotation.set(
         DEFAULT_PLAYER_ROTATION[0],
@@ -89,12 +97,31 @@ export default function Map({
       window.removeEventListener("keydown", handleKeyDown, {
         capture: true,
       });
-  }, []);
+  }, [resetPlayer]);
 
-  useFrame((_, delta) => {
+  useFrame((state, delta) => {
     // Rotate the world
     if (worldRef.current && rotateWorld && !interactiveMode) {
       worldRef.current.rotation.y += delta * ROTATION_SPEED;
+    }
+
+    if (isProcedural) {
+      const cameraPosition = new Vector3();
+      const cameraForward = new Vector3();
+      state.camera.getWorldPosition(cameraPosition);
+      state.camera.getWorldDirection(cameraForward);
+      updateFocus(gameStateRef.current.player.position, {
+        position: {
+          x: cameraPosition.x,
+          y: cameraPosition.y,
+          z: cameraPosition.z,
+        },
+        forward: {
+          x: cameraForward.x,
+          y: cameraForward.y,
+          z: cameraForward.z,
+        },
+      });
     }
   });
 
@@ -103,13 +130,39 @@ export default function Map({
     resetWorld();
   }, [interactiveMode]);
 
+  useEffect(() => {
+    gameStateRef.current = createGameState(activeWorld, playerStatePosition);
+    updateFocus(playerStatePosition);
+    resetPlayer();
+  }, [activeWorld, playerStatePosition, runtimeMode, updateFocus]);
+
   return (
     <group ref={worldRef} scale={[size, size, size]}>
+      <PlayerCameraFollow
+        enabled={interactiveMode}
+        gameStateRef={gameStateRef}
+      />
       <group position={[-4.5, 0, -4.5]}>
-        <WorldRenderer world={world} />
-        {showFringe ? <FringeRenderer world={world} /> : null}
+        {isProcedural && renderSnapshot ? (
+          <ProceduralMidDetailRenderer
+            columns={renderSnapshot.midDetailColumns}
+          />
+        ) : null}
+        <WorldRenderer
+          world={activeWorld}
+          detail={interactiveMode ? "full" : "preview"}
+          cells={isProcedural ? renderSnapshot?.highDetailCells : undefined}
+        />
+        {showFringe ? (
+          <FringeRenderer
+            world={activeWorld}
+            enableParticles={interactiveMode}
+            procedural={isProcedural}
+            snapshot={renderSnapshot}
+          />
+        ) : null}
         <Player
-          position={DEFAULT_PLAYER_POSITION}
+          position={playerPosition}
           animate={!interactiveMode}
           gameStateRef={gameStateRef}
           ref={playerRef}

--- a/src/components/world/player-camera-follow.tsx
+++ b/src/components/world/player-camera-follow.tsx
@@ -1,0 +1,37 @@
+import { useFrame } from "@react-three/fiber";
+import { type MutableRefObject, useMemo } from "react";
+import { Vector3 } from "three";
+import type { GameState } from "../../game/game";
+
+interface PlayerCameraFollowProps {
+  enabled: boolean;
+  gameStateRef: MutableRefObject<GameState>;
+}
+
+export default function PlayerCameraFollow({
+  enabled,
+  gameStateRef,
+}: PlayerCameraFollowProps) {
+  const cameraOffset = useMemo(() => new Vector3(8, 6, 8), []);
+  const lookOffset = useMemo(() => new Vector3(0, 1.1, 0), []);
+
+  useFrame(({ camera }, delta) => {
+    if (!enabled) {
+      return;
+    }
+
+    const { position } = gameStateRef.current.player;
+    const target = new Vector3(position.x, position.y, position.z).add(
+      lookOffset
+    );
+    const desiredPosition = new Vector3(position.x, position.y, position.z).add(
+      cameraOffset
+    );
+    const alpha = 1 - Math.exp(-8 * delta);
+
+    camera.position.lerp(desiredPosition, alpha);
+    camera.lookAt(target);
+  });
+
+  return null;
+}

--- a/src/components/world/use-world-runtime.ts
+++ b/src/components/world/use-world-runtime.ts
@@ -1,0 +1,91 @@
+import { useCallback, useMemo, useState } from "react";
+import { type Vec3 as StateVec3, vec3 } from "../../game/core/math/vec3";
+import type { ProceduralRuntimeMode } from "../../game/world/procedural/lod-policy";
+import { ProceduralWorldRuntime } from "../../game/world/procedural/procedural-runtime";
+import type { CameraSnapshotContext } from "../../game/world/procedural/render-snapshot";
+import { StarterRegion } from "../../game/world/procedural/starter-region";
+import { VoxelWorld } from "../../game/world/world";
+import { loadWorldCellsFromString } from "../../game/world/world-loader";
+import type { RenderableWorldQuery } from "../../game/world/world-query";
+import worldData from "./world-data";
+
+export type WorldMode = "static" | "procedural";
+export type Vec3 = [number, number, number];
+
+export const DEFAULT_PLAYER_POSITION: Vec3 = [9, 6, 1];
+export const DEFAULT_PLAYER_STATE_POSITION = vec3(9.5, 6, 1.5);
+export const DEFAULT_PLAYER_ROTATION: Vec3 = [0, 0, 0];
+export const DEFAULT_WORLD_ROTATION: Vec3 = [0, 0, 0];
+
+const staticWorldCells = loadWorldCellsFromString(worldData);
+const starterRegion = new StarterRegion(staticWorldCells);
+const staticWorld = new VoxelWorld(staticWorldCells);
+
+interface UseWorldRuntimeOptions {
+  worldMode: WorldMode;
+  interactiveMode: boolean;
+}
+
+interface FocusPosition {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export function useWorldRuntime({
+  worldMode,
+  interactiveMode,
+}: UseWorldRuntimeOptions) {
+  const [snapshotVersion, setSnapshotVersion] = useState(0);
+  const proceduralRuntime = useMemo(
+    () =>
+      new ProceduralWorldRuntime({
+        seed: 2026,
+        mode: "preview",
+        previewCenterX: 5,
+        previewCenterZ: 5,
+        starterRegion,
+      }),
+    []
+  );
+  const isProcedural = worldMode === "procedural";
+  const runtimeMode: ProceduralRuntimeMode = interactiveMode
+    ? "interactive"
+    : "preview";
+  const activeWorld: RenderableWorldQuery = isProcedural
+    ? proceduralRuntime.world
+    : staticWorld;
+
+  const updateFocus = useCallback(
+    (position: FocusPosition, camera?: CameraSnapshotContext | null) => {
+      if (!isProcedural) {
+        return;
+      }
+
+      const changed = proceduralRuntime.updateFocus(
+        position,
+        runtimeMode,
+        camera ?? null
+      );
+      if (changed) {
+        setSnapshotVersion((version) => version + 1);
+      }
+    },
+    [isProcedural, proceduralRuntime, runtimeMode]
+  );
+
+  const renderSnapshot = useMemo(
+    () => (isProcedural ? proceduralRuntime.createSnapshot() : null),
+    [isProcedural, proceduralRuntime, snapshotVersion]
+  );
+
+  return {
+    activeWorld,
+    isProcedural,
+    runtimeMode,
+    renderSnapshot,
+    updateFocus,
+    playerPosition: DEFAULT_PLAYER_POSITION,
+    playerStatePosition: DEFAULT_PLAYER_STATE_POSITION as StateVec3,
+  };
+}

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -2,16 +2,16 @@ import type { Vec3 } from "./core/math/vec3";
 import type { PlayerInputFrame } from "./core/types";
 import { createPlayerState, type PlayerState } from "./entities/player";
 import { simulatePlayerStep } from "./systems/player-controller";
-import type { VoxelWorld } from "./world/world";
+import type { WorldQuery } from "./world/world-query";
 
 export interface GameState {
-  world: VoxelWorld;
+  world: WorldQuery;
   player: PlayerState;
   elapsedTime: number;
 }
 
 export function createGameState(
-  world: VoxelWorld,
+  world: WorldQuery,
   playerStartPosition: Vec3
 ): GameState {
   return {

--- a/src/game/systems/input.ts
+++ b/src/game/systems/input.ts
@@ -9,7 +9,7 @@ import {
   FIXED_TIMESTEP,
   PLAYER_MOVE_SPEED,
 } from "../rules/constants";
-import type { VoxelWorld } from "../world/world";
+import type { WorldQuery } from "../world/world-query";
 
 export function createPlayerInputFrame(
   input: Partial<PlayerInputFrame> = {}
@@ -24,7 +24,7 @@ export function createPlayerInputFrame(
 
 export function createAutoplayInputFrame(
   player: PlayerState,
-  world: VoxelWorld
+  world: WorldQuery
 ): PlayerInputFrame {
   const direction =
     player.position.z <= AUTOPLAY_MIN_Z + 0.25
@@ -52,7 +52,7 @@ export function createAutoplayInputFrame(
 
 function shouldAutoplayJump(
   player: PlayerState,
-  world: VoxelWorld,
+  world: WorldQuery,
   input: PlayerInputFrame
 ): boolean {
   if (!player.grounded) {

--- a/src/game/systems/player-controller.ts
+++ b/src/game/systems/player-controller.ts
@@ -12,7 +12,7 @@ import {
   PLAYER_JUMP_VELOCITY,
   PLAYER_MOVE_SPEED,
 } from "../rules/constants";
-import type { VoxelWorld } from "../world/world";
+import type { WorldQuery } from "../world/world-query";
 
 type Axis = "x" | "y" | "z";
 
@@ -22,7 +22,7 @@ interface AxisResolution {
 }
 
 function resolveAxis(
-  world: VoxelWorld,
+  world: WorldQuery,
   aabb: ReturnType<typeof createBodyAABB>,
   axis: Axis,
   amount: number
@@ -113,7 +113,7 @@ function createMoveResult(previousGrounded: boolean): MoveResult {
 export function simulatePlayerStep(
   player: PlayerState,
   input: PlayerInputFrame,
-  world: VoxelWorld,
+  world: WorldQuery,
   dt: number
 ): PlayerState {
   const moveResult = createMoveResult(player.grounded);

--- a/src/game/world/procedural/chunk-coords.ts
+++ b/src/game/world/procedural/chunk-coords.ts
@@ -1,0 +1,31 @@
+export const CHUNK_SIZE_XZ = 16;
+export const WORLD_MIN_Y = 0;
+export const WORLD_MAX_Y = 32;
+
+export interface ChunkCoord {
+  chunkX: number;
+  chunkZ: number;
+}
+
+export function floorDiv(value: number, size: number): number {
+  return Math.floor(value / size);
+}
+
+export function worldToChunkCoord(x: number, z: number): ChunkCoord {
+  return {
+    chunkX: floorDiv(x, CHUNK_SIZE_XZ),
+    chunkZ: floorDiv(z, CHUNK_SIZE_XZ),
+  };
+}
+
+export function localCoord(value: number): number {
+  return ((value % CHUNK_SIZE_XZ) + CHUNK_SIZE_XZ) % CHUNK_SIZE_XZ;
+}
+
+export function chunkKey(chunkX: number, chunkZ: number): string {
+  return `${chunkX},${chunkZ}`;
+}
+
+export function chunkOrigin(chunkX: number, chunkZ: number): [number, number] {
+  return [chunkX * CHUNK_SIZE_XZ, chunkZ * CHUNK_SIZE_XZ];
+}

--- a/src/game/world/procedural/chunk-store.ts
+++ b/src/game/world/procedural/chunk-store.ts
@@ -1,0 +1,120 @@
+import type { VoxelChunk } from "./chunk";
+import { chunkKey } from "./chunk-coords";
+import { TerrainGenerator } from "./terrain-generator";
+
+export interface ChunkStoreOptions {
+  generator?: TerrainGenerator;
+  maxCachedChunks?: number;
+}
+
+export class ChunkStore {
+  private readonly generator: TerrainGenerator;
+  private readonly chunks = new Map<string, VoxelChunk>();
+  private maxCachedChunks: number;
+  private accessClock = 0;
+
+  constructor(options: ChunkStoreOptions = {}) {
+    this.generator = options.generator ?? new TerrainGenerator();
+    this.maxCachedChunks = options.maxCachedChunks ?? 81;
+  }
+
+  public setMaxCachedChunks(maxCachedChunks: number): void {
+    this.maxCachedChunks = maxCachedChunks;
+    this.evictStaleChunks();
+  }
+
+  public get size(): number {
+    return this.chunks.size;
+  }
+
+  public getLoadedChunks(): VoxelChunk[] {
+    return Array.from(this.chunks.values());
+  }
+
+  public hasChunk(chunkX: number, chunkZ: number): boolean {
+    return this.chunks.has(chunkKey(chunkX, chunkZ));
+  }
+
+  public getChunk(chunkX: number, chunkZ: number): VoxelChunk | null {
+    const chunk = this.chunks.get(chunkKey(chunkX, chunkZ));
+    if (!chunk) {
+      return null;
+    }
+
+    this.touch(chunk);
+    return chunk;
+  }
+
+  public ensureChunk(chunkX: number, chunkZ: number): VoxelChunk {
+    const key = chunkKey(chunkX, chunkZ);
+    const existing = this.chunks.get(key);
+    if (existing) {
+      this.touch(existing);
+      return existing;
+    }
+
+    const chunk = this.generator.generateChunk(chunkX, chunkZ);
+    this.touch(chunk);
+    this.chunks.set(key, chunk);
+    this.evictStaleChunks();
+    return chunk;
+  }
+
+  public ensureWindow(
+    centerChunkX: number,
+    centerChunkZ: number,
+    radius: number
+  ): VoxelChunk[] {
+    const chunks: VoxelChunk[] = [];
+    for (
+      let chunkZ = centerChunkZ - radius;
+      chunkZ <= centerChunkZ + radius;
+      chunkZ++
+    ) {
+      for (
+        let chunkX = centerChunkX - radius;
+        chunkX <= centerChunkX + radius;
+        chunkX++
+      ) {
+        chunks.push(this.ensureChunk(chunkX, chunkZ));
+      }
+    }
+
+    return chunks;
+  }
+
+  public retainWindow(
+    centerChunkX: number,
+    centerChunkZ: number,
+    radius: number
+  ): void {
+    for (const [key, chunk] of Array.from(this.chunks.entries())) {
+      const distance = Math.max(
+        Math.abs(chunk.chunkX - centerChunkX),
+        Math.abs(chunk.chunkZ - centerChunkZ)
+      );
+      if (distance > radius) {
+        this.chunks.delete(key);
+      }
+    }
+  }
+
+  private touch(chunk: VoxelChunk): void {
+    this.accessClock += 1;
+    chunk.lastAccessedAt = this.accessClock;
+  }
+
+  private evictStaleChunks(): void {
+    if (this.chunks.size <= this.maxCachedChunks) {
+      return;
+    }
+
+    const chunksByAccess = Array.from(this.chunks.values()).sort(
+      (a, b) => a.lastAccessedAt - b.lastAccessedAt
+    );
+    const evictCount = this.chunks.size - this.maxCachedChunks;
+    for (const chunk of chunksByAccess.slice(0, evictCount)) {
+      this.chunks.delete(chunkKey(chunk.chunkX, chunk.chunkZ));
+    }
+  }
+}

--- a/src/game/world/procedural/chunk.ts
+++ b/src/game/world/procedural/chunk.ts
@@ -1,0 +1,37 @@
+import type { LoadedWorldCell } from "../world-loader";
+import { CHUNK_SIZE_XZ, WORLD_MAX_Y, WORLD_MIN_Y } from "./chunk-coords";
+
+export type BiomeId = "grassland" | "beach" | "shallows" | "rocky";
+
+export interface GeneratedColumn {
+  height: number;
+  biome: BiomeId;
+  surfaceBlockId: number;
+  subsurfaceBlockId: number;
+  fluidLevel: number | null;
+}
+
+export interface VoxelChunk {
+  chunkX: number;
+  chunkZ: number;
+  minY: number;
+  maxY: number;
+  cells: LoadedWorldCell[];
+  exposedCells: LoadedWorldCell[];
+  heightmap: Int16Array;
+  biomes: BiomeId[];
+  generatedAt: number;
+  lastAccessedAt: number;
+}
+
+export function columnIndex(localX: number, localZ: number): number {
+  return localZ * CHUNK_SIZE_XZ + localX;
+}
+
+export function createEmptyHeightmap(): Int16Array {
+  return new Int16Array(CHUNK_SIZE_XZ * CHUNK_SIZE_XZ).fill(WORLD_MIN_Y);
+}
+
+export function clampWorldY(y: number): number {
+  return Math.max(WORLD_MIN_Y, Math.min(WORLD_MAX_Y, y));
+}

--- a/src/game/world/procedural/ground-blocks.ts
+++ b/src/game/world/procedural/ground-blocks.ts
@@ -1,0 +1,22 @@
+export const STONE = 1;
+export const GRASS = 2;
+export const DIRT = 3;
+export const WATER = 9;
+export const SAND = 12;
+
+export type GroundBlockId =
+  | typeof STONE
+  | typeof GRASS
+  | typeof DIRT
+  | typeof WATER
+  | typeof SAND;
+
+export function isGroundBlockId(id: number): id is GroundBlockId {
+  return (
+    id === STONE || id === GRASS || id === DIRT || id === WATER || id === SAND
+  );
+}
+
+export function isDryGroundBlockId(id: number): boolean {
+  return id === STONE || id === GRASS || id === DIRT || id === SAND;
+}

--- a/src/game/world/procedural/lod-policy.ts
+++ b/src/game/world/procedural/lod-policy.ts
@@ -105,15 +105,15 @@ export function sampleColumnLod(
   x: number,
   z: number,
   bounds: WorldBounds,
-  budget: LodBudget
+  _budget: LodBudget
 ): LodSample {
   const distanceFromFullDetail = columnDistanceFromBounds(x, z, bounds);
-  const midEnd = Math.max(3, budget.midDetailRadius * 4);
-  const wireEnd = Math.max(midEnd + 4, budget.wireRadius * 4 + 2);
-  const horizonEnd = Math.max(wireEnd + 4, budget.horizonRadius * 4 + 4);
+  const midEnd = 1;
+  const wireEnd = 2;
+  const horizonEnd = 4;
   const fidelity = 1 - smoothstep(0, wireEnd, distanceFromFullDetail);
   const blockOpacity =
-    distanceFromFullDetail === 0 ? 1 : smoothstep(0.62, 0.98, fidelity);
+    distanceFromFullDetail === 0 ? 1 : smoothstep(0.15, 1, fidelity);
   const midOpacity = clamp01(1 - Math.abs(fidelity - 0.55) / 0.45);
   const wireOpacity = 1 - smoothstep(0.25, 0.72, fidelity);
   const particleOpacity = 1 - smoothstep(0, 0.25, fidelity);
@@ -140,8 +140,8 @@ export function sampleColumnLod(
   };
 }
 
-export function getColumnLodSearchRadius(budget: LodBudget): number {
-  return Math.max(8, budget.horizonRadius * 4 + 4);
+export function getColumnLodSearchRadius(_budget: LodBudget): number {
+  return 4;
 }
 
 export function chunkChebyshevDistance(

--- a/src/game/world/procedural/lod-policy.ts
+++ b/src/game/world/procedural/lod-policy.ts
@@ -1,0 +1,157 @@
+import type { WorldBounds } from "../../core/types";
+
+export type ChunkLod = "high" | "mid" | "wire" | "horizon" | "unloaded";
+export const FULL_DETAIL_SIZE_XZ = 10;
+export type ProceduralRuntimeMode = "preview" | "interactive";
+
+export interface LodBudget {
+  highDetailRadius: number;
+  midDetailRadius: number;
+  wireRadius: number;
+  horizonRadius: number;
+  collisionRadius: number;
+  maxCachedChunks: number;
+  particlesEnabled: boolean;
+  shadowsEnabled: boolean;
+}
+
+export interface LodSample {
+  lod: ChunkLod;
+  fidelity: number;
+  blockOpacity: number;
+  midOpacity: number;
+  wireOpacity: number;
+  particleOpacity: number;
+  distanceFromFullDetail: number;
+}
+
+export const PROCEDURAL_LOD_BUDGETS: Record<ProceduralRuntimeMode, LodBudget> =
+  {
+    preview: {
+      highDetailRadius: 0,
+      midDetailRadius: 1,
+      wireRadius: 2,
+      horizonRadius: 3,
+      collisionRadius: 0,
+      maxCachedChunks: 25,
+      particlesEnabled: false,
+      shadowsEnabled: false,
+    },
+    interactive: {
+      highDetailRadius: 1,
+      midDetailRadius: 2,
+      wireRadius: 3,
+      horizonRadius: 4,
+      collisionRadius: 2,
+      maxCachedChunks: 81,
+      particlesEnabled: true,
+      shadowsEnabled: true,
+    },
+  };
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function smoothstep(edge0: number, edge1: number, value: number): number {
+  const t = clamp01((value - edge0) / (edge1 - edge0));
+  return t * t * (3 - 2 * t);
+}
+
+function columnDistanceFromBounds(
+  x: number,
+  z: number,
+  bounds: WorldBounds
+): number {
+  const dx =
+    x < bounds.min.x
+      ? bounds.min.x - x
+      : x > bounds.max.x
+        ? x - bounds.max.x
+        : 0;
+  const dz =
+    z < bounds.min.z
+      ? bounds.min.z - z
+      : z > bounds.max.z
+        ? z - bounds.max.z
+        : 0;
+  return Math.max(dx, dz);
+}
+
+export function classifyChunkLod(
+  distanceChunks: number,
+  budget: LodBudget
+): ChunkLod {
+  if (distanceChunks <= budget.highDetailRadius) {
+    return "high";
+  }
+
+  if (distanceChunks <= budget.midDetailRadius) {
+    return "mid";
+  }
+
+  if (distanceChunks <= budget.wireRadius) {
+    return "wire";
+  }
+
+  if (distanceChunks <= budget.horizonRadius) {
+    return "horizon";
+  }
+
+  return "unloaded";
+}
+
+export function sampleColumnLod(
+  x: number,
+  z: number,
+  bounds: WorldBounds,
+  budget: LodBudget
+): LodSample {
+  const distanceFromFullDetail = columnDistanceFromBounds(x, z, bounds);
+  const midEnd = Math.max(3, budget.midDetailRadius * 4);
+  const wireEnd = Math.max(midEnd + 4, budget.wireRadius * 4 + 2);
+  const horizonEnd = Math.max(wireEnd + 4, budget.horizonRadius * 4 + 4);
+  const fidelity = 1 - smoothstep(0, wireEnd, distanceFromFullDetail);
+  const blockOpacity =
+    distanceFromFullDetail === 0 ? 1 : smoothstep(0.62, 0.98, fidelity);
+  const midOpacity = clamp01(1 - Math.abs(fidelity - 0.55) / 0.45);
+  const wireOpacity = 1 - smoothstep(0.25, 0.72, fidelity);
+  const particleOpacity = 1 - smoothstep(0, 0.25, fidelity);
+  let lod: ChunkLod = "unloaded";
+
+  if (distanceFromFullDetail === 0 || blockOpacity > 0.55) {
+    lod = "high";
+  } else if (distanceFromFullDetail <= midEnd) {
+    lod = "mid";
+  } else if (distanceFromFullDetail <= wireEnd) {
+    lod = "wire";
+  } else if (distanceFromFullDetail <= horizonEnd) {
+    lod = "horizon";
+  }
+
+  return {
+    lod,
+    fidelity,
+    blockOpacity,
+    midOpacity,
+    wireOpacity,
+    particleOpacity,
+    distanceFromFullDetail,
+  };
+}
+
+export function getColumnLodSearchRadius(budget: LodBudget): number {
+  return Math.max(8, budget.horizonRadius * 4 + 4);
+}
+
+export function chunkChebyshevDistance(
+  chunkX: number,
+  chunkZ: number,
+  centerChunkX: number,
+  centerChunkZ: number
+): number {
+  return Math.max(
+    Math.abs(chunkX - centerChunkX),
+    Math.abs(chunkZ - centerChunkZ)
+  );
+}

--- a/src/game/world/procedural/procedural-runtime.ts
+++ b/src/game/world/procedural/procedural-runtime.ts
@@ -1,0 +1,71 @@
+import type { LoadedWorldCell } from "../world-loader";
+import type { ProceduralRuntimeMode } from "./lod-policy";
+import { ProceduralVoxelWorld } from "./procedural-world";
+import {
+  type CameraSnapshotContext,
+  createProceduralRenderSnapshot,
+  type ProceduralRenderSnapshot,
+  type RenderOrigin,
+} from "./render-snapshot";
+import { StarterRegion } from "./starter-region";
+
+export interface ProceduralWorldRuntimeOptions {
+  seed?: number;
+  mode?: ProceduralRuntimeMode;
+  previewCenterX?: number;
+  previewCenterZ?: number;
+  seedCells?: LoadedWorldCell[];
+  starterRegion?: StarterRegion;
+}
+
+export class ProceduralWorldRuntime {
+  public readonly world: ProceduralVoxelWorld;
+  public readonly starterRegion: StarterRegion | null;
+  private mode: ProceduralRuntimeMode;
+  private focus: RenderOrigin;
+  private camera: CameraSnapshotContext | null = null;
+
+  constructor(options: ProceduralWorldRuntimeOptions = {}) {
+    this.mode = options.mode ?? "preview";
+    this.focus = {
+      x: options.previewCenterX ?? 0,
+      y: 0,
+      z: options.previewCenterZ ?? 0,
+    };
+    this.starterRegion =
+      options.starterRegion ??
+      (options.seedCells ? new StarterRegion(options.seedCells) : null);
+    this.world = new ProceduralVoxelWorld({
+      seed: options.seed,
+      mode: this.mode,
+      centerX: options.previewCenterX,
+      centerZ: options.previewCenterZ,
+      starterRegion: this.starterRegion ?? undefined,
+    });
+  }
+
+  public updateFocus(
+    focus: RenderOrigin,
+    mode: ProceduralRuntimeMode = this.mode,
+    camera: CameraSnapshotContext | null = this.camera
+  ): boolean {
+    const previousMode = this.mode;
+    this.mode = mode;
+    this.focus = { ...focus };
+    this.camera = camera
+      ? { position: { ...camera.position }, forward: { ...camera.forward } }
+      : null;
+    const worldChanged = this.world.updateFocus(focus.x, focus.z, mode);
+
+    return worldChanged || previousMode !== mode;
+  }
+
+  public createSnapshot(): ProceduralRenderSnapshot {
+    return createProceduralRenderSnapshot({
+      world: this.world,
+      mode: this.mode,
+      focus: this.focus,
+      camera: this.camera,
+    });
+  }
+}

--- a/src/game/world/procedural/procedural-world.test.ts
+++ b/src/game/world/procedural/procedural-world.test.ts
@@ -8,6 +8,7 @@ import { loadWorldCellsFromString } from "../world-loader";
 import { columnIndex } from "./chunk";
 import { CHUNK_SIZE_XZ } from "./chunk-coords";
 import { ChunkStore } from "./chunk-store";
+import { GRASS, isGroundBlockId, SAND, WATER } from "./ground-blocks";
 import {
   classifyChunkLod,
   FULL_DETAIL_SIZE_XZ,
@@ -34,6 +35,26 @@ describe("StarterRegion", () => {
       expect(starterRegion.getBlockIdAtCell(cell.x, cell.y, cell.z)).toBe(
         cell.id
       );
+    }
+  });
+
+  it("derives seed heights only from ground blocks, not trees or leaves", () => {
+    const seedCells = loadWorldCellsFromString(worldData);
+    const starterRegion = new StarterRegion(seedCells);
+    const bounds = starterRegion.getBounds();
+
+    for (let z = bounds.min.z; z <= bounds.max.z; z++) {
+      for (let x = bounds.min.x; x <= bounds.max.x; x++) {
+        const height = starterRegion.getHighestGroundCell(x, z);
+
+        if (height === null) {
+          continue;
+        }
+
+        expect(
+          isGroundBlockId(starterRegion.getBlockIdAtCell(x, height, z))
+        ).toBe(true);
+      }
     }
   });
 });
@@ -71,7 +92,83 @@ describe("TerrainGenerator", () => {
     for (let z = 0; z < CHUNK_SIZE_XZ; z++) {
       const leftBoundary = left.heightmap[columnIndex(CHUNK_SIZE_XZ - 1, z)];
       const rightBoundary = right.heightmap[columnIndex(0, z)];
-      expect(Math.abs(leftBoundary - rightBoundary)).toBeLessThanOrEqual(4);
+      expect(Math.abs(leftBoundary - rightBoundary)).toBeLessThanOrEqual(2);
+    }
+  });
+
+  it("limits adjacent ground elevation deltas in every direction", () => {
+    const generator = new TerrainGenerator({ seed: 29 });
+
+    for (let z = -12; z <= 12; z++) {
+      for (let x = -12; x <= 12; x++) {
+        const height = generator.getColumn(x, z).height;
+        expect(
+          Math.abs(height - generator.getColumn(x + 1, z).height)
+        ).toBeLessThanOrEqual(2);
+        expect(
+          Math.abs(height - generator.getColumn(x, z + 1).height)
+        ).toBeLessThanOrEqual(2);
+      }
+    }
+  });
+
+  it("does not generate elevated water over air", () => {
+    const generator = new TerrainGenerator({ seed: 37 });
+    const chunk = generator.generateChunk(-1, 1);
+
+    for (const cell of chunk.cells) {
+      if (cell.id !== WATER) {
+        continue;
+      }
+
+      expect(generator.getBlockIdAtCell(cell.x, cell.y - 1, cell.z)).not.toBe(
+        0
+      );
+    }
+  });
+
+  it("uses transition bands before switching from grass seed edges to sand", () => {
+    const seedCells = loadWorldCellsFromString(worldData);
+    const starterRegion = new StarterRegion(seedCells);
+    const generator = new TerrainGenerator({ seed: 17, starterRegion });
+    const bounds = starterRegion.getBounds();
+    const grassEdgeTransitions: Array<{
+      fromX: number;
+      fromZ: number;
+      toX: number;
+      toZ: number;
+    }> = [];
+    const maybeAddGrassEdge = (
+      fromX: number,
+      fromZ: number,
+      toX: number,
+      toZ: number
+    ) => {
+      const height = starterRegion.getHighestGroundCell(fromX, fromZ);
+      if (height === null) {
+        return;
+      }
+
+      if (starterRegion.getBlockIdAtCell(fromX, height, fromZ) === GRASS) {
+        grassEdgeTransitions.push({ fromX, fromZ, toX, toZ });
+      }
+    };
+
+    for (let x = bounds.min.x; x <= bounds.max.x; x++) {
+      maybeAddGrassEdge(x, bounds.min.z, x, bounds.min.z - 1);
+      maybeAddGrassEdge(x, bounds.max.z, x, bounds.max.z + 1);
+    }
+
+    for (let z = bounds.min.z; z <= bounds.max.z; z++) {
+      maybeAddGrassEdge(bounds.min.x, z, bounds.min.x - 1, z);
+      maybeAddGrassEdge(bounds.max.x, z, bounds.max.x + 1, z);
+    }
+
+    expect(grassEdgeTransitions.length).toBeGreaterThan(0);
+
+    for (const transition of grassEdgeTransitions.slice(0, 12)) {
+      const generated = generator.getColumn(transition.toX, transition.toZ);
+      expect(generated.surfaceBlockId).not.toBe(SAND);
     }
   });
 });
@@ -132,9 +229,43 @@ describe("ProceduralWorldRuntime", () => {
     );
     expect(snapshot.midDetailColumns.length).toBeGreaterThan(0);
     expect(snapshot.wireColumns.length).toBeGreaterThan(0);
+    expect(snapshot.wireColumns.every((column) => column.opacity <= 1)).toBe(
+      true
+    );
     expect(
-      new Set(snapshot.wireColumns.map((column) => column.opacity)).size
-    ).toBeGreaterThan(1);
+      Math.max(...snapshot.wireColumns.map((column) => column.distanceBand))
+    ).toBeLessThanOrEqual(2);
+  });
+
+  it("keeps faded proxy terrain from blocking the player or camera corridor", () => {
+    const runtime = new ProceduralWorldRuntime({
+      seed: 19,
+      mode: "interactive",
+      previewCenterX: 5,
+      previewCenterZ: 5,
+      seedCells: loadWorldCellsFromString(worldData),
+    });
+
+    runtime.updateFocus({ x: 5, y: 0, z: 5 }, "interactive", {
+      position: { x: 15, y: 9, z: 5 },
+      forward: { x: -1, y: 0, z: 0 },
+    });
+    const snapshot = runtime.createSnapshot();
+    const corridorColumns = snapshot.midDetailColumns.filter(
+      (column) => column.x >= 10 && column.z >= 4 && column.z <= 6
+    );
+
+    expect(corridorColumns.length).toBeGreaterThan(0);
+    expect(
+      Math.max(...corridorColumns.map((column) => column.opacity))
+    ).toBeLessThanOrEqual(0.15);
+    expect(
+      snapshot.wireColumns.every(
+        (column) =>
+          Math.hypot(column.x - snapshot.focus.x, column.z - snapshot.focus.z) >
+          1.75
+      )
+    ).toBe(true);
   });
 });
 
@@ -279,7 +410,7 @@ describe("procedural LOD policy", () => {
       PROCEDURAL_LOD_BUDGETS.interactive
     );
     const far = sampleColumnLod(
-      18,
+      11,
       5,
       bounds,
       PROCEDURAL_LOD_BUDGETS.interactive
@@ -287,5 +418,6 @@ describe("procedural LOD policy", () => {
 
     expect(near.blockOpacity).toBeGreaterThan(far.blockOpacity);
     expect(far.wireOpacity).toBeGreaterThan(near.wireOpacity);
+    expect(far.distanceFromFullDetail).toBeLessThanOrEqual(2);
   });
 });

--- a/src/game/world/procedural/procedural-world.test.ts
+++ b/src/game/world/procedural/procedural-world.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "bun:test";
+import worldData from "../../../components/world/world-data";
+import { createBodyAABB } from "../../core/math/aabb";
+import { vec3 } from "../../core/math/vec3";
+import { PLAYER_COLLIDER } from "../../rules/constants";
+import { VoxelWorld } from "../world";
+import { loadWorldCellsFromString } from "../world-loader";
+import { columnIndex } from "./chunk";
+import { CHUNK_SIZE_XZ } from "./chunk-coords";
+import { ChunkStore } from "./chunk-store";
+import {
+  classifyChunkLod,
+  FULL_DETAIL_SIZE_XZ,
+  PROCEDURAL_LOD_BUDGETS,
+  sampleColumnLod,
+} from "./lod-policy";
+import { ProceduralWorldRuntime } from "./procedural-runtime";
+import { ProceduralVoxelWorld } from "./procedural-world";
+import { StarterRegion } from "./starter-region";
+import { TerrainGenerator } from "./terrain-generator";
+
+describe("StarterRegion", () => {
+  it("indexes authored seed cells without generating replacement blocks", () => {
+    const seedCells = loadWorldCellsFromString(worldData);
+    const starterRegion = new StarterRegion(seedCells);
+    const bounds = starterRegion.getBounds();
+
+    expect(bounds.min.x).toBe(0);
+    expect(bounds.min.z).toBe(0);
+    expect(bounds.max.x).toBe(9);
+    expect(bounds.max.z).toBe(9);
+
+    for (const cell of seedCells.slice(0, 25)) {
+      expect(starterRegion.getBlockIdAtCell(cell.x, cell.y, cell.z)).toBe(
+        cell.id
+      );
+    }
+  });
+});
+
+describe("TerrainGenerator", () => {
+  it("generates deterministic chunks for a seed", () => {
+    const first = new TerrainGenerator({ seed: 42 }).generateChunk(1, -2);
+    const second = new TerrainGenerator({ seed: 42 }).generateChunk(1, -2);
+
+    expect(Array.from(first.heightmap)).toEqual(Array.from(second.heightmap));
+    expect(first.exposedCells).toEqual(second.exposedCells);
+  });
+
+  it("blends generated columns away from the authored seed edge", () => {
+    const seedCells = loadWorldCellsFromString(worldData);
+    const starterRegion = new StarterRegion(seedCells);
+    const generator = new TerrainGenerator({ seed: 17, starterRegion });
+
+    for (let x = 0; x <= 9; x++) {
+      const seedHeight = starterRegion.getHighestSolidCell(x, 0);
+      const generatedHeight = generator.getColumn(x, -1).height;
+
+      expect(seedHeight).not.toBeNull();
+      expect(
+        Math.abs(generatedHeight - (seedHeight as number))
+      ).toBeLessThanOrEqual(2);
+    }
+  });
+
+  it("keeps heights continuous across chunk boundaries", () => {
+    const generator = new TerrainGenerator({ seed: 7 });
+    const left = generator.generateChunk(0, 0);
+    const right = generator.generateChunk(1, 0);
+
+    for (let z = 0; z < CHUNK_SIZE_XZ; z++) {
+      const leftBoundary = left.heightmap[columnIndex(CHUNK_SIZE_XZ - 1, z)];
+      const rightBoundary = right.heightmap[columnIndex(0, z)];
+      expect(Math.abs(leftBoundary - rightBoundary)).toBeLessThanOrEqual(4);
+    }
+  });
+});
+
+describe("ChunkStore", () => {
+  it("evicts least-recently-used chunks when over budget", () => {
+    const store = new ChunkStore({
+      generator: new TerrainGenerator({ seed: 1 }),
+      maxCachedChunks: 2,
+    });
+
+    store.ensureChunk(0, 0);
+    store.ensureChunk(1, 0);
+    store.ensureChunk(2, 0);
+
+    expect(store.size).toBe(2);
+    expect(store.hasChunk(0, 0)).toBe(false);
+    expect(store.hasChunk(1, 0)).toBe(true);
+    expect(store.hasChunk(2, 0)).toBe(true);
+  });
+});
+
+describe("ProceduralWorldRuntime", () => {
+  it("keeps preview snapshots anchored to the authored 10x10 seed", () => {
+    const seedCells = loadWorldCellsFromString(worldData);
+    const runtime = new ProceduralWorldRuntime({
+      seed: 19,
+      mode: "preview",
+      previewCenterX: 5,
+      previewCenterZ: 5,
+      seedCells,
+    });
+
+    runtime.updateFocus({ x: 100, y: 0, z: 100 }, "preview");
+    const snapshot = runtime.createSnapshot();
+
+    expect(snapshot.fullDetailBounds.min.x).toBe(0);
+    expect(snapshot.fullDetailBounds.min.z).toBe(0);
+    expect(snapshot.fullDetailBounds.max.x).toBe(9);
+    expect(snapshot.fullDetailBounds.max.z).toBe(9);
+    expect(snapshot.mode).toBe("preview");
+  });
+
+  it("builds overlapping fade bands in render snapshots", () => {
+    const runtime = new ProceduralWorldRuntime({
+      seed: 19,
+      mode: "interactive",
+      previewCenterX: 5,
+      previewCenterZ: 5,
+      seedCells: loadWorldCellsFromString(worldData),
+    });
+
+    runtime.updateFocus({ x: 5, y: 0, z: 5 }, "interactive");
+    const snapshot = runtime.createSnapshot();
+
+    expect(snapshot.highDetailCells.some((cell) => cell.opacity < 1)).toBe(
+      true
+    );
+    expect(snapshot.midDetailColumns.length).toBeGreaterThan(0);
+    expect(snapshot.wireColumns.length).toBeGreaterThan(0);
+    expect(
+      new Set(snapshot.wireColumns.map((column) => column.opacity)).size
+    ).toBeGreaterThan(1);
+  });
+});
+
+describe("ProceduralVoxelWorld", () => {
+  it("answers block and collision queries across chunk boundaries", () => {
+    const world = new ProceduralVoxelWorld({ seed: 5, mode: "interactive" });
+    const leftHeight = world.getHighestSolidCell(CHUNK_SIZE_XZ - 1, 0);
+    const rightHeight = world.getHighestSolidCell(CHUNK_SIZE_XZ, 0);
+
+    expect(leftHeight).not.toBeNull();
+    expect(rightHeight).not.toBeNull();
+    expect(world.isCellSolid(CHUNK_SIZE_XZ - 1, leftHeight as number, 0)).toBe(
+      true
+    );
+    expect(world.isCellSolid(CHUNK_SIZE_XZ, rightHeight as number, 0)).toBe(
+      true
+    );
+  });
+
+  it("keeps the fully rendered procedural footprint at 10x10 columns", () => {
+    const world = new ProceduralVoxelWorld({ seed: 17, mode: "interactive" });
+    const bounds = world.getBounds();
+    const cells = world.getRenderableCells();
+    const renderedColumns = new Set(cells.map((cell) => `${cell.x},${cell.z}`));
+
+    expect(bounds.max.x - bounds.min.x + 1).toBe(FULL_DETAIL_SIZE_XZ);
+    expect(bounds.max.z - bounds.min.z + 1).toBe(FULL_DETAIL_SIZE_XZ);
+    expect(renderedColumns.size).toBe(
+      FULL_DETAIL_SIZE_XZ * FULL_DETAIL_SIZE_XZ
+    );
+    expect(
+      cells.every(
+        (cell) =>
+          cell.x >= bounds.min.x &&
+          cell.x <= bounds.max.x &&
+          cell.z >= bounds.min.z &&
+          cell.z <= bounds.max.z
+      )
+    ).toBe(true);
+  });
+
+  it("keeps preview bounds anchored even as focus updates", () => {
+    const world = new ProceduralVoxelWorld({
+      seed: 17,
+      mode: "preview",
+      centerX: 5,
+      centerZ: 5,
+    });
+    const initialBounds = world.getBounds();
+
+    world.updateFocus(100, 100, "preview");
+
+    expect(world.getBounds()).toEqual(initialBounds);
+  });
+
+  it("uses the existing static map as the initial 10x10 seed area", () => {
+    const seedCells = loadWorldCellsFromString(worldData);
+    const world = new ProceduralVoxelWorld({
+      seed: 17,
+      mode: "preview",
+      centerX: 5,
+      centerZ: 5,
+      seedCells,
+    });
+    const bounds = world.getBounds();
+
+    expect(bounds.min.x).toBe(0);
+    expect(bounds.min.z).toBe(0);
+    expect(bounds.max.x).toBe(9);
+    expect(bounds.max.z).toBe(9);
+
+    for (const cell of seedCells) {
+      expect(world.getBlockIdAtCell(cell.x, cell.y, cell.z)).toBe(cell.id);
+    }
+  });
+
+  it("matches the static map exposed cells for the seeded 10x10 preview", () => {
+    const seedCells = loadWorldCellsFromString(worldData);
+    const staticWorld = new VoxelWorld(seedCells);
+    const proceduralWorld = new ProceduralVoxelWorld({
+      seed: 17,
+      mode: "preview",
+      centerX: 5,
+      centerZ: 5,
+      seedCells,
+    });
+    const staticKeys = new Set(
+      staticWorld
+        .getExposedRenderableCells()
+        .map((cell) => `${cell.x},${cell.y},${cell.z},${cell.id}`)
+    );
+    const proceduralKeys = new Set(
+      proceduralWorld
+        .getExposedRenderableCells()
+        .map((cell) => `${cell.x},${cell.y},${cell.z},${cell.id}`)
+    );
+
+    expect(proceduralKeys).toEqual(staticKeys);
+  });
+
+  it("places spawn above generated terrain", () => {
+    const world = new ProceduralVoxelWorld({ seed: 11 });
+    const spawn = world.findSpawnColumn(0, 0);
+
+    expect(world.isCellSolid(spawn.x, spawn.y - 1, spawn.z)).toBe(true);
+    expect(world.isCellSolid(spawn.x, spawn.y, spawn.z)).toBe(false);
+  });
+
+  it("collides with generated ground", () => {
+    const world = new ProceduralVoxelWorld({ seed: 13, mode: "interactive" });
+    const spawn = world.findSpawnColumn(0, 0);
+    const aabb = createBodyAABB(
+      vec3(spawn.x + 0.5, spawn.y - 0.9, spawn.z + 0.5),
+      PLAYER_COLLIDER
+    );
+
+    expect(world.collidesAABB(aabb)).toBe(true);
+  });
+});
+
+describe("procedural LOD policy", () => {
+  it("keeps preview mode lightweight", () => {
+    const budget = PROCEDURAL_LOD_BUDGETS.preview;
+
+    expect(classifyChunkLod(0, budget)).toBe("high");
+    expect(classifyChunkLod(1, budget)).toBe("mid");
+    expect(classifyChunkLod(2, budget)).toBe("wire");
+    expect(classifyChunkLod(4, budget)).toBe("unloaded");
+    expect(budget.particlesEnabled).toBe(false);
+    expect(budget.shadowsEnabled).toBe(false);
+  });
+
+  it("returns continuous opacity samples by column distance", () => {
+    const bounds = {
+      min: { x: 0, y: 0, z: 0 },
+      max: { x: 9, y: 4, z: 9 },
+    };
+    const near = sampleColumnLod(
+      10,
+      5,
+      bounds,
+      PROCEDURAL_LOD_BUDGETS.interactive
+    );
+    const far = sampleColumnLod(
+      18,
+      5,
+      bounds,
+      PROCEDURAL_LOD_BUDGETS.interactive
+    );
+
+    expect(near.blockOpacity).toBeGreaterThan(far.blockOpacity);
+    expect(far.wireOpacity).toBeGreaterThan(near.wireOpacity);
+  });
+});

--- a/src/game/world/procedural/procedural-world.ts
+++ b/src/game/world/procedural/procedural-world.ts
@@ -1,0 +1,318 @@
+import type { AABB } from "../../core/math/aabb";
+import type { CellCoord, CollisionKind, WorldBounds } from "../../core/types";
+import { COLLISION_EPSILON } from "../../rules/constants";
+import {
+  type BlockDefinition,
+  getBlockDefinition,
+  isBlockFluid,
+  isBlockSolid,
+} from "../block-registry";
+import type { FluidAdjacency } from "../world";
+import type { LoadedWorldCell } from "../world-loader";
+import type { RenderableWorldQuery } from "../world-query";
+import { WORLD_MIN_Y, worldToChunkCoord } from "./chunk-coords";
+import { ChunkStore } from "./chunk-store";
+import {
+  FULL_DETAIL_SIZE_XZ,
+  type LodBudget,
+  PROCEDURAL_LOD_BUDGETS,
+  type ProceduralRuntimeMode,
+} from "./lod-policy";
+import { StarterRegion } from "./starter-region";
+import { TerrainGenerator } from "./terrain-generator";
+
+const STONE = 1;
+
+export interface ProceduralVoxelWorldOptions {
+  seed?: number;
+  mode?: ProceduralRuntimeMode;
+  centerX?: number;
+  centerZ?: number;
+  seedCells?: LoadedWorldCell[];
+  starterRegion?: StarterRegion;
+}
+
+export interface SpawnColumn {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export class ProceduralVoxelWorld implements RenderableWorldQuery {
+  private readonly generator: TerrainGenerator;
+  private readonly store: ChunkStore;
+  private mode: ProceduralRuntimeMode;
+  private centerChunkX = 0;
+  private centerChunkZ = 0;
+  private focusCellX = 0;
+  private focusCellZ = 0;
+  private readonly previewFocusCellX: number;
+  private readonly previewFocusCellZ: number;
+
+  constructor(options: ProceduralVoxelWorldOptions = {}) {
+    this.mode = options.mode ?? "preview";
+    this.previewFocusCellX = Math.floor(options.centerX ?? 0);
+    this.previewFocusCellZ = Math.floor(options.centerZ ?? 0);
+    this.generator = new TerrainGenerator({
+      seed: options.seed,
+      starterRegion:
+        options.starterRegion ??
+        (options.seedCells ? new StarterRegion(options.seedCells) : undefined),
+    });
+    this.store = new ChunkStore({
+      generator: this.generator,
+      maxCachedChunks: this.budget.maxCachedChunks,
+    });
+    this.updateFocus(options.centerX ?? 0, options.centerZ ?? 0, this.mode);
+  }
+
+  public get budget(): LodBudget {
+    return PROCEDURAL_LOD_BUDGETS[this.mode];
+  }
+
+  public updateFocus(
+    x: number,
+    z: number,
+    mode: ProceduralRuntimeMode = this.mode
+  ): boolean {
+    const previousMode = this.mode;
+    const previousChunkX = this.centerChunkX;
+    const previousChunkZ = this.centerChunkZ;
+    const previousFocusCellX = this.focusCellX;
+    const previousFocusCellZ = this.focusCellZ;
+
+    this.mode = mode;
+    this.store.setMaxCachedChunks(this.budget.maxCachedChunks);
+
+    this.focusCellX =
+      mode === "preview" ? this.previewFocusCellX : Math.floor(x);
+    this.focusCellZ =
+      mode === "preview" ? this.previewFocusCellZ : Math.floor(z);
+    const { chunkX, chunkZ } = worldToChunkCoord(
+      this.focusCellX,
+      this.focusCellZ
+    );
+    this.centerChunkX = chunkX;
+    this.centerChunkZ = chunkZ;
+    const residentRenderRadius = Math.max(
+      this.budget.highDetailRadius,
+      this.budget.midDetailRadius
+    );
+    this.store.ensureWindow(chunkX, chunkZ, residentRenderRadius);
+    this.store.retainWindow(chunkX, chunkZ, residentRenderRadius);
+
+    return (
+      previousMode !== mode ||
+      previousChunkX !== chunkX ||
+      previousChunkZ !== chunkZ ||
+      previousFocusCellX !== this.focusCellX ||
+      previousFocusCellZ !== this.focusCellZ
+    );
+  }
+
+  public findSpawnColumn(x = 0, z = 0): SpawnColumn {
+    const height = this.getHighestSolidCell(x, z) ?? WORLD_MIN_Y;
+    return { x, y: height + 1, z };
+  }
+
+  public getBounds(): WorldBounds {
+    return this.getFullDetailBounds();
+  }
+
+  public getFullDetailBounds(): WorldBounds {
+    const halfSize = Math.floor(FULL_DETAIL_SIZE_XZ / 2);
+    const minX = this.focusCellX - halfSize;
+    const minZ = this.focusCellZ - halfSize;
+    const maxX = minX + FULL_DETAIL_SIZE_XZ - 1;
+    const maxZ = minZ + FULL_DETAIL_SIZE_XZ - 1;
+    let maxY = WORLD_MIN_Y;
+
+    for (let z = minZ; z <= maxZ; z++) {
+      for (let x = minX; x <= maxX; x++) {
+        const column = this.generator.getColumn(x, z);
+        maxY = Math.max(maxY, column.fluidLevel ?? column.height);
+      }
+    }
+
+    return {
+      min: { x: minX, y: WORLD_MIN_Y, z: minZ },
+      max: { x: maxX, y: maxY, z: maxZ },
+    };
+  }
+
+  public getRenderableCells(): LoadedWorldCell[] {
+    return this.getCellsForActiveWindow("full");
+  }
+
+  public getExposedRenderableCells(): LoadedWorldCell[] {
+    return this.getCellsForActiveWindow("preview");
+  }
+
+  public getBlockIdAtCell(x: number, y: number, z: number): number {
+    if (y < WORLD_MIN_Y) {
+      return STONE;
+    }
+
+    return this.generator.getBlockIdAtCell(x, y, z);
+  }
+
+  public getBlockAtCell(x: number, y: number, z: number): BlockDefinition {
+    return getBlockDefinition(this.getBlockIdAtCell(x, y, z));
+  }
+
+  public getCollisionKind(x: number, y: number, z: number): CollisionKind {
+    return this.getBlockAtCell(x, y, z).collisionKind;
+  }
+
+  public isCellSolid(x: number, y: number, z: number): boolean {
+    return isBlockSolid(this.getBlockIdAtCell(x, y, z));
+  }
+
+  public isCellFluid(x: number, y: number, z: number): boolean {
+    return isBlockFluid(this.getBlockIdAtCell(x, y, z));
+  }
+
+  public getFluidAdjacency(x: number, y: number, z: number): FluidAdjacency {
+    return {
+      top: this.isCellFluid(x, y + 1, z),
+      bottom: this.isCellFluid(x, y - 1, z),
+      north: this.isCellFluid(x, y, z - 1),
+      south: this.isCellFluid(x, y, z + 1),
+      east: this.isCellFluid(x + 1, y, z),
+      west: this.isCellFluid(x - 1, y, z),
+    };
+  }
+
+  public getHighestSolidCell(x: number, z: number): number | null {
+    return this.generator.getColumn(x, z).height;
+  }
+
+  public getRenderableColumnCells(
+    x: number,
+    z: number,
+    detail: "full" | "preview" = "preview"
+  ): LoadedWorldCell[] {
+    const column = this.generator.getColumn(x, z);
+    const cells: LoadedWorldCell[] = [];
+    const maxY = column.fluidLevel ?? column.height;
+
+    for (let y = WORLD_MIN_Y; y <= maxY; y++) {
+      const id = this.getBlockIdAtCell(x, y, z);
+      if (id === 0) {
+        continue;
+      }
+
+      const cell = { x, y, z, id };
+      if (detail === "full" || this.hasExposedFace(cell)) {
+        cells.push(cell);
+      }
+    }
+
+    return cells;
+  }
+
+  public getOverlappingCells(aabb: AABB): CellCoord[] {
+    const minX = Math.floor(aabb.min.x + COLLISION_EPSILON);
+    const maxX = Math.floor(aabb.max.x - COLLISION_EPSILON);
+    const minY = Math.floor(aabb.min.y + COLLISION_EPSILON);
+    const maxY = Math.floor(aabb.max.y - COLLISION_EPSILON);
+    const minZ = Math.floor(aabb.min.z + COLLISION_EPSILON);
+    const maxZ = Math.floor(aabb.max.z - COLLISION_EPSILON);
+
+    const cells: CellCoord[] = [];
+    for (let x = minX; x <= maxX; x++) {
+      for (let y = minY; y <= maxY; y++) {
+        for (let z = minZ; z <= maxZ; z++) {
+          cells.push({ x, y, z });
+        }
+      }
+    }
+
+    return cells;
+  }
+
+  public collidesAABB(aabb: AABB): boolean {
+    if (aabb.min.y < WORLD_MIN_Y) {
+      return true;
+    }
+
+    this.ensureCollisionChunks(aabb);
+
+    for (const cell of this.getOverlappingCells(aabb)) {
+      if (this.isCellSolid(cell.x, cell.y, cell.z)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private hasExposedFace(cell: LoadedWorldCell): boolean {
+    const neighborOffsets = [
+      [1, 0, 0],
+      [-1, 0, 0],
+      [0, 1, 0],
+      [0, -1, 0],
+      [0, 0, 1],
+      [0, 0, -1],
+    ] as const;
+
+    return neighborOffsets.some(([dx, dy, dz]) => {
+      const neighborY = cell.y + dy;
+
+      if (neighborY < WORLD_MIN_Y) {
+        return false;
+      }
+
+      return this.getBlockIdAtCell(cell.x + dx, neighborY, cell.z + dz) === 0;
+    });
+  }
+
+  private getCellsForActiveWindow(
+    detail: "full" | "preview"
+  ): LoadedWorldCell[] {
+    const bounds = this.getFullDetailBounds();
+    const cells: LoadedWorldCell[] = [];
+
+    for (const chunk of this.store.getLoadedChunks()) {
+      const sourceCells = detail === "full" ? chunk.cells : chunk.exposedCells;
+      for (const cell of sourceCells) {
+        if (this.isWithinFullDetailFootprint(cell.x, cell.z, bounds)) {
+          cells.push(cell);
+        }
+      }
+    }
+
+    return cells;
+  }
+
+  private isWithinFullDetailFootprint(
+    x: number,
+    z: number,
+    bounds = this.getFullDetailBounds()
+  ): boolean {
+    return (
+      x >= bounds.min.x &&
+      x <= bounds.max.x &&
+      z >= bounds.min.z &&
+      z <= bounds.max.z
+    );
+  }
+
+  private ensureCollisionChunks(aabb: AABB): void {
+    const min = worldToChunkCoord(
+      Math.floor(aabb.min.x),
+      Math.floor(aabb.min.z)
+    );
+    const max = worldToChunkCoord(
+      Math.floor(aabb.max.x),
+      Math.floor(aabb.max.z)
+    );
+
+    for (let chunkZ = min.chunkZ; chunkZ <= max.chunkZ; chunkZ++) {
+      for (let chunkX = min.chunkX; chunkX <= max.chunkX; chunkX++) {
+        this.store.ensureChunk(chunkX, chunkZ);
+      }
+    }
+  }
+}

--- a/src/game/world/procedural/render-snapshot.ts
+++ b/src/game/world/procedural/render-snapshot.ts
@@ -86,6 +86,58 @@ function normalize2d(x: number, z: number): { x: number; z: number } {
   return { x: x / length, z: z / length };
 }
 
+function distancePointToSegment2d(
+  pointX: number,
+  pointZ: number,
+  start: RenderOrigin,
+  end: RenderOrigin
+): { distance: number; onSegment: boolean } {
+  const segmentX = end.x - start.x;
+  const segmentZ = end.z - start.z;
+  const lengthSquared = segmentX * segmentX + segmentZ * segmentZ;
+
+  if (lengthSquared === 0) {
+    return {
+      distance: Math.hypot(pointX - end.x, pointZ - end.z),
+      onSegment: false,
+    };
+  }
+
+  const t =
+    ((pointX - start.x) * segmentX + (pointZ - start.z) * segmentZ) /
+    lengthSquared;
+  const clampedT = Math.max(0, Math.min(1, t));
+  const closestX = start.x + segmentX * clampedT;
+  const closestZ = start.z + segmentZ * clampedT;
+
+  return {
+    distance: Math.hypot(pointX - closestX, pointZ - closestZ),
+    onSegment: t >= 0 && t <= 1,
+  };
+}
+
+function playerVisibilityMultiplier(
+  x: number,
+  z: number,
+  focus: RenderOrigin,
+  camera: CameraSnapshotContext | null | undefined
+): number {
+  if (Math.hypot(x - focus.x, z - focus.z) <= 1.75) {
+    return 0;
+  }
+
+  if (!camera) {
+    return 1;
+  }
+
+  const occlusion = distancePointToSegment2d(x, z, camera.position, focus);
+  if (occlusion.onSegment && occlusion.distance <= 1.1) {
+    return 0.1;
+  }
+
+  return 1;
+}
+
 function viewRelevance(
   x: number,
   z: number,
@@ -134,7 +186,8 @@ export function createProceduralRenderSnapshot({
         continue;
       }
 
-      const relevance = viewRelevance(x, z, focus, camera);
+      const visibility = playerVisibilityMultiplier(x, z, focus, camera);
+      const relevance = viewRelevance(x, z, focus, camera) * visibility;
       lodSamples.push({ x, z, ...sample });
 
       if (sample.blockOpacity > 0.03) {
@@ -145,7 +198,10 @@ export function createProceduralRenderSnapshot({
         highDetailCells.push(
           ...world.getRenderableColumnCells(x, z, "preview").map((cell) => ({
             ...cell,
-            opacity,
+            opacity:
+              sample.distanceFromFullDetail === 0
+                ? opacity
+                : opacity * visibility,
             fidelity: sample.fidelity,
           }))
         );
@@ -154,19 +210,28 @@ export function createProceduralRenderSnapshot({
       const height = world.getHighestSolidCell(x, z) ?? WORLD_MIN_Y;
       const surfaceBlockId = world.getBlockIdAtCell(x, height, z);
 
-      if (sample.midOpacity > 0.03) {
+      if (
+        sample.midOpacity > 0.03 &&
+        sample.distanceFromFullDetail > 0 &&
+        visibility > 0
+      ) {
         midDetailColumns.push({
           x,
           z,
           y: WORLD_MIN_Y,
           height,
           surfaceBlockId,
-          opacity: sample.midOpacity,
+          opacity: sample.midOpacity * visibility,
           fidelity: sample.fidelity,
         });
       }
 
-      if (sample.wireOpacity > 0.03) {
+      if (
+        sample.wireOpacity > 0.03 &&
+        sample.distanceFromFullDetail > 1 &&
+        sample.distanceFromFullDetail <= 2 &&
+        visibility > 0
+      ) {
         wireColumns.push({
           x,
           z,
@@ -178,7 +243,11 @@ export function createProceduralRenderSnapshot({
         });
       }
 
-      if (sample.lod === "horizon" && sample.particleOpacity > 0.03) {
+      if (
+        sample.lod === "horizon" &&
+        sample.particleOpacity > 0.03 &&
+        visibility > 0
+      ) {
         const tile = {
           x,
           z,

--- a/src/game/world/procedural/render-snapshot.ts
+++ b/src/game/world/procedural/render-snapshot.ts
@@ -1,0 +1,210 @@
+import type { WorldBounds } from "../../core/types";
+import type { LoadedWorldCell } from "../world-loader";
+import { WORLD_MIN_Y } from "./chunk-coords";
+import {
+  getColumnLodSearchRadius,
+  type LodSample,
+  type ProceduralRuntimeMode,
+  sampleColumnLod,
+} from "./lod-policy";
+import type { ProceduralVoxelWorld } from "./procedural-world";
+
+export interface RenderOrigin {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface CameraSnapshotContext {
+  position: RenderOrigin;
+  forward: RenderOrigin;
+}
+
+export interface HighDetailCell extends LoadedWorldCell {
+  opacity: number;
+  fidelity: number;
+}
+
+export interface MidDetailColumn {
+  x: number;
+  z: number;
+  y: number;
+  height: number;
+  surfaceBlockId: number;
+  opacity: number;
+  fidelity: number;
+}
+
+export interface WireColumn {
+  x: number;
+  z: number;
+  minY: number;
+  maxY: number;
+  opacity: number;
+  fidelity: number;
+  distanceBand: number;
+}
+
+export interface SnapshotGridTile {
+  x: number;
+  z: number;
+  opacity: number;
+  row: number;
+  emissionWeight: number;
+  fidelity: number;
+}
+
+export interface ProceduralRenderSnapshot {
+  mode: ProceduralRuntimeMode;
+  focus: RenderOrigin;
+  cameraPosition: RenderOrigin | null;
+  cameraForward: RenderOrigin | null;
+  renderOrigin: RenderOrigin;
+  fullDetailBounds: WorldBounds;
+  lodSamples: Array<LodSample & { x: number; z: number }>;
+  highDetailCells: HighDetailCell[];
+  midDetailColumns: MidDetailColumn[];
+  wireColumns: WireColumn[];
+  gridTiles: SnapshotGridTile[];
+  particleTiles: SnapshotGridTile[];
+}
+
+export interface ProceduralRenderSnapshotOptions {
+  world: ProceduralVoxelWorld;
+  mode: ProceduralRuntimeMode;
+  focus: RenderOrigin;
+  renderOrigin?: RenderOrigin;
+  camera?: CameraSnapshotContext | null;
+}
+
+function normalize2d(x: number, z: number): { x: number; z: number } {
+  const length = Math.hypot(x, z);
+  if (length === 0) {
+    return { x: 0, z: 1 };
+  }
+
+  return { x: x / length, z: z / length };
+}
+
+function viewRelevance(
+  x: number,
+  z: number,
+  focus: RenderOrigin,
+  camera: CameraSnapshotContext | null | undefined
+): number {
+  if (!camera) {
+    return 1;
+  }
+
+  const toColumn = normalize2d(x - camera.position.x, z - camera.position.z);
+  const forward = normalize2d(camera.forward.x, camera.forward.z);
+  const facing = Math.max(0, toColumn.x * forward.x + toColumn.z * forward.z);
+  const lateralDistance = Math.abs(
+    (x - focus.x) * forward.z - (z - focus.z) * forward.x
+  );
+  const lateralFade = 1 - Math.min(1, Math.max(0, (lateralDistance - 4) / 10));
+
+  return Math.max(0.12, facing) * lateralFade;
+}
+
+export function createProceduralRenderSnapshot({
+  world,
+  mode,
+  focus,
+  renderOrigin = { x: 0, y: 0, z: 0 },
+  camera = null,
+}: ProceduralRenderSnapshotOptions): ProceduralRenderSnapshot {
+  const fullDetailBounds = world.getFullDetailBounds();
+  const searchRadius = getColumnLodSearchRadius(world.budget);
+  const minX = fullDetailBounds.min.x - searchRadius;
+  const maxX = fullDetailBounds.max.x + searchRadius;
+  const minZ = fullDetailBounds.min.z - searchRadius;
+  const maxZ = fullDetailBounds.max.z + searchRadius;
+  const lodSamples: Array<LodSample & { x: number; z: number }> = [];
+  const highDetailCells: HighDetailCell[] = [];
+  const midDetailColumns: MidDetailColumn[] = [];
+  const wireColumns: WireColumn[] = [];
+  const gridTiles: SnapshotGridTile[] = [];
+  const particleTiles: SnapshotGridTile[] = [];
+
+  for (let z = minZ; z <= maxZ; z++) {
+    for (let x = minX; x <= maxX; x++) {
+      const sample = sampleColumnLod(x, z, fullDetailBounds, world.budget);
+      if (sample.lod === "unloaded") {
+        continue;
+      }
+
+      const relevance = viewRelevance(x, z, focus, camera);
+      lodSamples.push({ x, z, ...sample });
+
+      if (sample.blockOpacity > 0.03) {
+        const opacity =
+          mode === "preview" && sample.distanceFromFullDetail === 0
+            ? 1
+            : sample.blockOpacity;
+        highDetailCells.push(
+          ...world.getRenderableColumnCells(x, z, "preview").map((cell) => ({
+            ...cell,
+            opacity,
+            fidelity: sample.fidelity,
+          }))
+        );
+      }
+
+      const height = world.getHighestSolidCell(x, z) ?? WORLD_MIN_Y;
+      const surfaceBlockId = world.getBlockIdAtCell(x, height, z);
+
+      if (sample.midOpacity > 0.03) {
+        midDetailColumns.push({
+          x,
+          z,
+          y: WORLD_MIN_Y,
+          height,
+          surfaceBlockId,
+          opacity: sample.midOpacity,
+          fidelity: sample.fidelity,
+        });
+      }
+
+      if (sample.wireOpacity > 0.03) {
+        wireColumns.push({
+          x,
+          z,
+          minY: WORLD_MIN_Y,
+          maxY: Math.max(WORLD_MIN_Y, height),
+          opacity: sample.wireOpacity * relevance,
+          fidelity: sample.fidelity,
+          distanceBand: sample.distanceFromFullDetail,
+        });
+      }
+
+      if (sample.lod === "horizon" && sample.particleOpacity > 0.03) {
+        const tile = {
+          x,
+          z,
+          opacity: sample.particleOpacity * relevance,
+          row: Math.max(1, Math.round(sample.distanceFromFullDetail)),
+          emissionWeight: sample.particleOpacity * relevance,
+          fidelity: sample.fidelity,
+        };
+        gridTiles.push(tile);
+        particleTiles.push(tile);
+      }
+    }
+  }
+
+  return {
+    mode,
+    focus: { ...focus },
+    cameraPosition: camera ? { ...camera.position } : null,
+    cameraForward: camera ? { ...camera.forward } : null,
+    renderOrigin: { ...renderOrigin },
+    fullDetailBounds,
+    lodSamples,
+    highDetailCells,
+    midDetailColumns,
+    wireColumns,
+    gridTiles,
+    particleTiles,
+  };
+}

--- a/src/game/world/procedural/starter-region.ts
+++ b/src/game/world/procedural/starter-region.ts
@@ -1,0 +1,194 @@
+import { isBlockSolid } from "../block-registry";
+import type { LoadedWorldCell } from "../world-loader";
+import { WORLD_MIN_Y } from "./chunk-coords";
+
+function cellKey(x: number, y: number, z: number): string {
+  return `${x},${y},${z}`;
+}
+
+function columnKey(x: number, z: number): string {
+  return `${x},${z}`;
+}
+
+export interface MaterialWeights {
+  grass: number;
+  dirt: number;
+  sand: number;
+  stone: number;
+  water: number;
+}
+
+export interface SeedEdgeSample {
+  x: number;
+  z: number;
+  height: number;
+  surfaceBlockId: number;
+  materialWeights: MaterialWeights;
+  distance: number;
+}
+
+const emptyMaterialWeights: MaterialWeights = {
+  grass: 0,
+  dirt: 0,
+  sand: 0,
+  stone: 0,
+  water: 0,
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function weightsForBlockId(blockId: number): MaterialWeights {
+  switch (blockId) {
+    case 2:
+      return { ...emptyMaterialWeights, grass: 1 };
+    case 3:
+      return { ...emptyMaterialWeights, dirt: 1 };
+    case 9:
+      return { ...emptyMaterialWeights, water: 1 };
+    case 12:
+      return { ...emptyMaterialWeights, sand: 1 };
+    default:
+      return { ...emptyMaterialWeights, stone: 1 };
+  }
+}
+
+export class StarterRegion {
+  private readonly cells: LoadedWorldCell[];
+  private readonly blockIds = new Map<string, number>();
+  private readonly columns = new Map<string, LoadedWorldCell[]>();
+  private readonly solidHeights = new Map<string, number>();
+  private readonly minX: number;
+  private readonly minY: number;
+  private readonly minZ: number;
+  private readonly maxX: number;
+  private readonly maxY: number;
+  private readonly maxZ: number;
+
+  constructor(cells: LoadedWorldCell[]) {
+    this.cells = cells.map((cell) => ({ ...cell }));
+
+    let minX = Number.POSITIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    let minZ = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+    let maxZ = Number.NEGATIVE_INFINITY;
+
+    for (const cell of this.cells) {
+      const key = columnKey(cell.x, cell.z);
+      this.blockIds.set(cellKey(cell.x, cell.y, cell.z), cell.id);
+      const column = this.columns.get(key) ?? [];
+      column.push(cell);
+      this.columns.set(key, column);
+
+      if (isBlockSolid(cell.id)) {
+        this.solidHeights.set(
+          key,
+          Math.max(this.solidHeights.get(key) ?? WORLD_MIN_Y, cell.y)
+        );
+      }
+
+      minX = Math.min(minX, cell.x);
+      minY = Math.min(minY, cell.y);
+      minZ = Math.min(minZ, cell.z);
+      maxX = Math.max(maxX, cell.x);
+      maxY = Math.max(maxY, cell.y);
+      maxZ = Math.max(maxZ, cell.z);
+    }
+
+    for (const column of Array.from(this.columns.values())) {
+      column.sort((a, b) => a.y - b.y);
+    }
+
+    this.minX = Number.isFinite(minX) ? minX : 0;
+    this.minY = Number.isFinite(minY) ? minY : WORLD_MIN_Y;
+    this.minZ = Number.isFinite(minZ) ? minZ : 0;
+    this.maxX = Number.isFinite(maxX) ? maxX : 0;
+    this.maxY = Number.isFinite(maxY) ? maxY : WORLD_MIN_Y;
+    this.maxZ = Number.isFinite(maxZ) ? maxZ : 0;
+  }
+
+  public hasColumn(x: number, z: number): boolean {
+    return this.columns.has(columnKey(x, z));
+  }
+
+  public isInsideFootprint(x: number, z: number): boolean {
+    return x >= this.minX && x <= this.maxX && z >= this.minZ && z <= this.maxZ;
+  }
+
+  public getDistanceToFootprint(x: number, z: number): number {
+    const dx =
+      x < this.minX ? this.minX - x : x > this.maxX ? x - this.maxX : 0;
+    const dz =
+      z < this.minZ ? this.minZ - z : z > this.maxZ ? z - this.maxZ : 0;
+    return Math.max(dx, dz);
+  }
+
+  public getNearestEdgeSample(x: number, z: number): SeedEdgeSample | null {
+    if (this.cells.length === 0) {
+      return null;
+    }
+
+    const edgeX = clamp(x, this.minX, this.maxX);
+    const edgeZ = clamp(z, this.minZ, this.maxZ);
+    const height = this.getHighestSolidCell(edgeX, edgeZ);
+
+    if (height === null) {
+      return null;
+    }
+
+    const surfaceBlockId = this.getBlockIdAtCell(edgeX, height, edgeZ);
+    return {
+      x: edgeX,
+      z: edgeZ,
+      height,
+      surfaceBlockId,
+      materialWeights: this.getEdgeMaterialWeights(edgeX, edgeZ),
+      distance: this.getDistanceToFootprint(x, z),
+    };
+  }
+
+  public getEdgeMaterialWeights(x: number, z: number): MaterialWeights {
+    const height = this.getHighestSolidCell(x, z);
+    if (height === null) {
+      return { ...emptyMaterialWeights };
+    }
+
+    return weightsForBlockId(this.getBlockIdAtCell(x, height, z));
+  }
+
+  public getBlockIdAtCell(x: number, y: number, z: number): number {
+    return this.blockIds.get(cellKey(x, y, z)) ?? 0;
+  }
+
+  public getColumnCells(x: number, z: number): LoadedWorldCell[] {
+    return (this.columns.get(columnKey(x, z)) ?? []).map((cell) => ({
+      ...cell,
+    }));
+  }
+
+  public getHighestSolidCell(x: number, z: number): number | null {
+    return this.solidHeights.get(columnKey(x, z)) ?? null;
+  }
+
+  public getCells(): LoadedWorldCell[] {
+    return this.cells.map((cell) => ({ ...cell }));
+  }
+
+  public getCenter(): { x: number; y: number; z: number } {
+    return {
+      x: (this.minX + this.maxX) / 2,
+      y: (this.minY + this.maxY) / 2,
+      z: (this.minZ + this.maxZ) / 2,
+    };
+  }
+
+  public getBounds() {
+    return {
+      min: { x: this.minX, y: this.minY, z: this.minZ },
+      max: { x: this.maxX, y: this.maxY, z: this.maxZ },
+    };
+  }
+}

--- a/src/game/world/procedural/starter-region.ts
+++ b/src/game/world/procedural/starter-region.ts
@@ -1,6 +1,6 @@
-import { isBlockSolid } from "../block-registry";
 import type { LoadedWorldCell } from "../world-loader";
 import { WORLD_MIN_Y } from "./chunk-coords";
+import { DIRT, GRASS, isGroundBlockId, SAND, WATER } from "./ground-blocks";
 
 function cellKey(x: number, y: number, z: number): string {
   return `${x},${y},${z}`;
@@ -41,13 +41,13 @@ function clamp(value: number, min: number, max: number): number {
 
 function weightsForBlockId(blockId: number): MaterialWeights {
   switch (blockId) {
-    case 2:
+    case GRASS:
       return { ...emptyMaterialWeights, grass: 1 };
-    case 3:
+    case DIRT:
       return { ...emptyMaterialWeights, dirt: 1 };
-    case 9:
+    case WATER:
       return { ...emptyMaterialWeights, water: 1 };
-    case 12:
+    case SAND:
       return { ...emptyMaterialWeights, sand: 1 };
     default:
       return { ...emptyMaterialWeights, stone: 1 };
@@ -83,7 +83,7 @@ export class StarterRegion {
       column.push(cell);
       this.columns.set(key, column);
 
-      if (isBlockSolid(cell.id)) {
+      if (isGroundBlockId(cell.id)) {
         this.solidHeights.set(
           key,
           Math.max(this.solidHeights.get(key) ?? WORLD_MIN_Y, cell.y)
@@ -170,6 +170,10 @@ export class StarterRegion {
   }
 
   public getHighestSolidCell(x: number, z: number): number | null {
+    return this.getHighestGroundCell(x, z);
+  }
+
+  public getHighestGroundCell(x: number, z: number): number | null {
     return this.solidHeights.get(columnKey(x, z)) ?? null;
   }
 

--- a/src/game/world/procedural/terrain-generator.ts
+++ b/src/game/world/procedural/terrain-generator.ts
@@ -1,0 +1,358 @@
+import type { LoadedWorldCell } from "../world-loader";
+import {
+  type BiomeId,
+  clampWorldY,
+  columnIndex,
+  createEmptyHeightmap,
+  type GeneratedColumn,
+  type VoxelChunk,
+} from "./chunk";
+import { CHUNK_SIZE_XZ, chunkOrigin, WORLD_MIN_Y } from "./chunk-coords";
+import { StarterRegion } from "./starter-region";
+
+const STONE = 1;
+const GRASS = 2;
+const DIRT = 3;
+const WATER = 9;
+const SAND = 12;
+const WATER_LEVEL = 5;
+const SEED_HEIGHT_BLEND_RADIUS = 10;
+const SEED_MATERIAL_BLEND_RADIUS = 6;
+
+export interface TerrainGeneratorOptions {
+  seed?: number;
+  seedCells?: LoadedWorldCell[];
+  starterRegion?: StarterRegion;
+}
+
+function fract(value: number): number {
+  return value - Math.floor(value);
+}
+
+function hash2d(x: number, z: number, seed: number): number {
+  const n = Math.sin(x * 127.1 + z * 311.7 + seed * 74.7) * 43758.5453;
+  return fract(n);
+}
+
+function smoothstep(value: number): number {
+  return value * value * (3 - 2 * value);
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function valueNoise(x: number, z: number, seed: number): number {
+  const x0 = Math.floor(x);
+  const z0 = Math.floor(z);
+  const tx = smoothstep(x - x0);
+  const tz = smoothstep(z - z0);
+
+  const a = hash2d(x0, z0, seed);
+  const b = hash2d(x0 + 1, z0, seed);
+  const c = hash2d(x0, z0 + 1, seed);
+  const d = hash2d(x0 + 1, z0 + 1, seed);
+
+  const ab = a + (b - a) * tx;
+  const cd = c + (d - c) * tx;
+  return ab + (cd - ab) * tz;
+}
+
+function terrainNoise(x: number, z: number, seed: number): number {
+  const broad = valueNoise(x / 48, z / 48, seed) * 2 - 1;
+  const rolling = valueNoise(x / 18, z / 18, seed + 13) * 2 - 1;
+  const detail = valueNoise(x / 7, z / 7, seed + 29) * 2 - 1;
+  return broad * 5 + rolling * 2.5 + detail * 0.8;
+}
+
+function biomeForHeight(height: number, slopeSignal: number): BiomeId {
+  if (height <= WATER_LEVEL - 1) {
+    return "shallows";
+  }
+
+  if (height <= WATER_LEVEL + 1) {
+    return "beach";
+  }
+
+  if (height >= 12 || slopeSignal > 0.72) {
+    return "rocky";
+  }
+
+  return "grassland";
+}
+
+export class TerrainGenerator {
+  private readonly seed: number;
+  private readonly starterRegion: StarterRegion | null;
+
+  constructor(options: TerrainGeneratorOptions = {}) {
+    this.seed = options.seed ?? 1337;
+    this.starterRegion =
+      options.starterRegion ??
+      (options.seedCells ? new StarterRegion(options.seedCells) : null);
+  }
+
+  public getColumn(x: number, z: number): GeneratedColumn {
+    const seededHeight = this.starterRegion?.getHighestSolidCell(x, z);
+    if (seededHeight !== undefined && seededHeight !== null) {
+      const surfaceBlockId = this.getBlockIdAtCell(x, seededHeight, z);
+      const subsurfaceBlockId =
+        this.getBlockIdAtCell(x, seededHeight - 1, z) || surfaceBlockId;
+
+      return {
+        height: seededHeight,
+        biome: surfaceBlockId === SAND ? "beach" : "grassland",
+        surfaceBlockId,
+        subsurfaceBlockId,
+        fluidLevel: null,
+      };
+    }
+
+    return this.applySeedTransition(x, z, this.getRawColumn(x, z));
+  }
+
+  private getRawColumn(x: number, z: number): GeneratedColumn {
+    const noise = terrainNoise(x, z, this.seed);
+    const slopeSignal = valueNoise(x / 10, z / 10, this.seed + 101);
+    const height = clampWorldY(Math.round(7 + noise));
+    const biome = biomeForHeight(height, slopeSignal);
+
+    if (biome === "shallows" || biome === "beach") {
+      return {
+        height,
+        biome,
+        surfaceBlockId: SAND,
+        subsurfaceBlockId: SAND,
+        fluidLevel: height < WATER_LEVEL ? WATER_LEVEL : null,
+      };
+    }
+
+    if (biome === "rocky") {
+      return {
+        height,
+        biome,
+        surfaceBlockId: STONE,
+        subsurfaceBlockId: STONE,
+        fluidLevel: null,
+      };
+    }
+
+    return {
+      height,
+      biome,
+      surfaceBlockId: GRASS,
+      subsurfaceBlockId: DIRT,
+      fluidLevel: null,
+    };
+  }
+
+  private applySeedTransition(
+    x: number,
+    z: number,
+    rawColumn: GeneratedColumn
+  ): GeneratedColumn {
+    const edgeSample = this.starterRegion?.getNearestEdgeSample(x, z);
+    if (!edgeSample || edgeSample.distance > SEED_HEIGHT_BLEND_RADIUS) {
+      return rawColumn;
+    }
+
+    const heightBlend =
+      1 - smoothstep(clamp01(edgeSample.distance / SEED_HEIGHT_BLEND_RADIUS));
+    const materialBlend =
+      1 - smoothstep(clamp01(edgeSample.distance / SEED_MATERIAL_BLEND_RADIUS));
+    const edgeSlopeOffset = Math.max(
+      -3,
+      Math.min(
+        3,
+        edgeSample.distance *
+          (rawColumn.height > edgeSample.height ? 0.35 : -0.25)
+      )
+    );
+    const height = clampWorldY(
+      Math.round(
+        lerp(rawColumn.height, edgeSample.height + edgeSlopeOffset, heightBlend)
+      )
+    );
+    const surfaceBlockId = this.pickTransitionSurfaceBlock(
+      rawColumn,
+      edgeSample.surfaceBlockId,
+      materialBlend,
+      height
+    );
+    const subsurfaceBlockId =
+      surfaceBlockId === GRASS
+        ? DIRT
+        : surfaceBlockId === WATER
+          ? SAND
+          : surfaceBlockId;
+
+    return {
+      height,
+      biome:
+        surfaceBlockId === SAND
+          ? "beach"
+          : surfaceBlockId === STONE
+            ? "rocky"
+            : "grassland",
+      surfaceBlockId,
+      subsurfaceBlockId,
+      fluidLevel:
+        surfaceBlockId === SAND && height < WATER_LEVEL ? WATER_LEVEL : null,
+    };
+  }
+
+  private pickTransitionSurfaceBlock(
+    rawColumn: GeneratedColumn,
+    seedSurfaceBlockId: number,
+    materialBlend: number,
+    height: number
+  ): number {
+    if (materialBlend <= 0) {
+      return rawColumn.surfaceBlockId;
+    }
+
+    if (seedSurfaceBlockId === SAND || seedSurfaceBlockId === WATER) {
+      return height <= WATER_LEVEL + 1 || materialBlend > 0.25
+        ? SAND
+        : rawColumn.surfaceBlockId;
+    }
+
+    if (seedSurfaceBlockId === GRASS || seedSurfaceBlockId === DIRT) {
+      if (height <= WATER_LEVEL) {
+        return SAND;
+      }
+
+      return materialBlend > 0.2 ? GRASS : rawColumn.surfaceBlockId;
+    }
+
+    if (seedSurfaceBlockId === STONE) {
+      return rawColumn.biome === "rocky" || materialBlend > 0.65
+        ? STONE
+        : rawColumn.surfaceBlockId;
+    }
+
+    return rawColumn.surfaceBlockId;
+  }
+
+  public getBlockIdAtCell(x: number, y: number, z: number): number {
+    if (this.starterRegion?.hasColumn(x, z)) {
+      return this.starterRegion.getBlockIdAtCell(x, y, z);
+    }
+
+    const column = this.getColumn(x, z);
+    if (y < WORLD_MIN_Y) {
+      return STONE;
+    }
+
+    if (y <= column.height) {
+      if (y === column.height) {
+        return column.surfaceBlockId;
+      }
+
+      return y >= column.height - 3 ? column.subsurfaceBlockId : STONE;
+    }
+
+    if (column.fluidLevel !== null && y <= column.fluidLevel) {
+      return WATER;
+    }
+
+    return 0;
+  }
+
+  public generateChunk(chunkX: number, chunkZ: number): VoxelChunk {
+    const [originX, originZ] = chunkOrigin(chunkX, chunkZ);
+    const cells: LoadedWorldCell[] = [];
+    const heightmap = createEmptyHeightmap();
+    const biomes: BiomeId[] = [];
+
+    for (let localZ = 0; localZ < CHUNK_SIZE_XZ; localZ++) {
+      for (let localX = 0; localX < CHUNK_SIZE_XZ; localX++) {
+        const worldX = originX + localX;
+        const worldZ = originZ + localZ;
+        const column = this.getColumn(worldX, worldZ);
+        const index = columnIndex(localX, localZ);
+        heightmap[index] = column.height;
+        biomes[index] = column.biome;
+
+        if (this.starterRegion?.hasColumn(worldX, worldZ)) {
+          cells.push(...this.starterRegion.getColumnCells(worldX, worldZ));
+          continue;
+        }
+
+        for (let y = WORLD_MIN_Y; y <= column.height; y++) {
+          const id =
+            y === column.height
+              ? column.surfaceBlockId
+              : y >= column.height - 3
+                ? column.subsurfaceBlockId
+                : STONE;
+          cells.push({ x: worldX, y, z: worldZ, id });
+        }
+
+        if (column.fluidLevel !== null) {
+          for (let y = column.height + 1; y <= column.fluidLevel; y++) {
+            cells.push({ x: worldX, y, z: worldZ, id: WATER });
+          }
+        }
+      }
+    }
+
+    let maxY = WATER_LEVEL;
+    for (let index = 0; index < heightmap.length; index++) {
+      maxY = Math.max(maxY, heightmap[index]);
+    }
+
+    const generatedAt = Date.now();
+    return {
+      chunkX,
+      chunkZ,
+      minY: WORLD_MIN_Y,
+      maxY,
+      cells,
+      exposedCells: cells.filter((cell) => this.hasExposedFace(cell)),
+      heightmap,
+      biomes,
+      generatedAt,
+      lastAccessedAt: generatedAt,
+    };
+  }
+
+  private hasExposedFace(cell: LoadedWorldCell): boolean {
+    const isStarterCell =
+      this.starterRegion?.hasColumn(cell.x, cell.z) ?? false;
+    const neighborOffsets = [
+      [1, 0, 0],
+      [-1, 0, 0],
+      [0, 1, 0],
+      [0, -1, 0],
+      [0, 0, 1],
+      [0, 0, -1],
+    ] as const;
+
+    return neighborOffsets.some(([dx, dy, dz]) => {
+      const neighborX = cell.x + dx;
+      const neighborY = cell.y + dy;
+      const neighborZ = cell.z + dz;
+
+      if (isStarterCell) {
+        return (
+          this.starterRegion?.getBlockIdAtCell(
+            neighborX,
+            neighborY,
+            neighborZ
+          ) === 0
+        );
+      }
+
+      if (neighborY < WORLD_MIN_Y) {
+        return false;
+      }
+
+      return this.getBlockIdAtCell(neighborX, neighborY, neighborZ) === 0;
+    });
+  }
+}

--- a/src/game/world/procedural/terrain-generator.ts
+++ b/src/game/world/procedural/terrain-generator.ts
@@ -8,16 +8,13 @@ import {
   type VoxelChunk,
 } from "./chunk";
 import { CHUNK_SIZE_XZ, chunkOrigin, WORLD_MIN_Y } from "./chunk-coords";
+import { DIRT, GRASS, SAND, STONE, WATER } from "./ground-blocks";
 import { StarterRegion } from "./starter-region";
 
-const STONE = 1;
-const GRASS = 2;
-const DIRT = 3;
-const WATER = 9;
-const SAND = 12;
 const WATER_LEVEL = 5;
 const SEED_HEIGHT_BLEND_RADIUS = 10;
 const SEED_MATERIAL_BLEND_RADIUS = 6;
+const MAX_NEIGHBOR_GROUND_DELTA = 1;
 
 export interface TerrainGeneratorOptions {
   seed?: number;
@@ -32,6 +29,67 @@ function fract(value: number): number {
 function hash2d(x: number, z: number, seed: number): number {
   const n = Math.sin(x * 127.1 + z * 311.7 + seed * 74.7) * 43758.5453;
   return fract(n);
+}
+
+function gradientVector(
+  ix: number,
+  iz: number,
+  seed: number
+): [number, number] {
+  const angle = hash2d(ix, iz, seed) * Math.PI * 2;
+  return [Math.cos(angle), Math.sin(angle)];
+}
+
+function fade(value: number): number {
+  return value * value * value * (value * (value * 6 - 15) + 10);
+}
+
+function gradientNoise(x: number, z: number, seed: number): number {
+  const x0 = Math.floor(x);
+  const z0 = Math.floor(z);
+  const x1 = x0 + 1;
+  const z1 = z0 + 1;
+  const sx = fade(x - x0);
+  const sz = fade(z - z0);
+  const [g00x, g00z] = gradientVector(x0, z0, seed);
+  const [g10x, g10z] = gradientVector(x1, z0, seed);
+  const [g01x, g01z] = gradientVector(x0, z1, seed);
+  const [g11x, g11z] = gradientVector(x1, z1, seed);
+  const n00 = g00x * (x - x0) + g00z * (z - z0);
+  const n10 = g10x * (x - x1) + g10z * (z - z0);
+  const n01 = g01x * (x - x0) + g01z * (z - z1);
+  const n11 = g11x * (x - x1) + g11z * (z - z1);
+  const ix0 = lerp(n00, n10, sx);
+  const ix1 = lerp(n01, n11, sx);
+
+  return lerp(ix0, ix1, sz) * Math.SQRT2;
+}
+
+function fbmNoise(
+  x: number,
+  z: number,
+  seed: number,
+  octaves: number,
+  frequency = 1
+): number {
+  let value = 0;
+  let amplitude = 0.5;
+  let totalAmplitude = 0;
+  let currentFrequency = frequency;
+
+  for (let octave = 0; octave < octaves; octave++) {
+    value +=
+      gradientNoise(
+        x * currentFrequency,
+        z * currentFrequency,
+        seed + octave * 53
+      ) * amplitude;
+    totalAmplitude += amplitude;
+    amplitude *= 0.5;
+    currentFrequency *= 2;
+  }
+
+  return value / totalAmplitude;
 }
 
 function smoothstep(value: number): number {
@@ -63,10 +121,15 @@ function valueNoise(x: number, z: number, seed: number): number {
 }
 
 function terrainNoise(x: number, z: number, seed: number): number {
-  const broad = valueNoise(x / 48, z / 48, seed) * 2 - 1;
-  const rolling = valueNoise(x / 18, z / 18, seed + 13) * 2 - 1;
-  const detail = valueNoise(x / 7, z / 7, seed + 29) * 2 - 1;
-  return broad * 5 + rolling * 2.5 + detail * 0.8;
+  const warpX = fbmNoise(x / 40, z / 40, seed + 200, 2) * 3;
+  const warpZ = fbmNoise(x / 40, z / 40, seed + 260, 2) * 3;
+  const sampleX = x + warpX;
+  const sampleZ = z + warpZ;
+  const continentalness = fbmNoise(sampleX / 42, sampleZ / 42, seed, 4);
+  const erosion = fbmNoise(sampleX / 24, sampleZ / 24, seed + 13, 3);
+  const detail = fbmNoise(sampleX / 9, sampleZ / 9, seed + 29, 2);
+
+  return continentalness * 4 - erosion * 1.25 + detail * 0.55;
 }
 
 function biomeForHeight(height: number, slopeSignal: number): BiomeId {
@@ -118,16 +181,21 @@ export class TerrainGenerator {
   private getRawColumn(x: number, z: number): GeneratedColumn {
     const noise = terrainNoise(x, z, this.seed);
     const slopeSignal = valueNoise(x / 10, z / 10, this.seed + 101);
-    const height = clampWorldY(Math.round(7 + noise));
+    const height = this.smoothGeneratedHeight(
+      x,
+      z,
+      clampWorldY(Math.round(7 + noise))
+    );
     const biome = biomeForHeight(height, slopeSignal);
 
     if (biome === "shallows" || biome === "beach") {
+      const supportedWaterLevel = this.getSupportedWaterLevel(x, z, height);
       return {
         height,
         biome,
         surfaceBlockId: SAND,
         subsurfaceBlockId: SAND,
-        fluidLevel: height < WATER_LEVEL ? WATER_LEVEL : null,
+        fluidLevel: supportedWaterLevel,
       };
     }
 
@@ -201,8 +269,61 @@ export class TerrainGenerator {
       surfaceBlockId,
       subsurfaceBlockId,
       fluidLevel:
-        surfaceBlockId === SAND && height < WATER_LEVEL ? WATER_LEVEL : null,
+        surfaceBlockId === SAND
+          ? this.getSupportedWaterLevel(x, z, height)
+          : null,
     };
+  }
+
+  private smoothGeneratedHeight(
+    x: number,
+    z: number,
+    rawHeight: number
+  ): number {
+    const neighborRawHeights = [
+      this.getRawHeightOnly(x + 1, z),
+      this.getRawHeightOnly(x - 1, z),
+      this.getRawHeightOnly(x, z + 1),
+      this.getRawHeightOnly(x, z - 1),
+    ];
+    const averageNeighborHeight = Math.round(
+      neighborRawHeights.reduce((sum, height) => sum + height, 0) /
+        neighborRawHeights.length
+    );
+    return clampWorldY(
+      Math.max(
+        averageNeighborHeight - MAX_NEIGHBOR_GROUND_DELTA,
+        Math.min(averageNeighborHeight + MAX_NEIGHBOR_GROUND_DELTA, rawHeight)
+      )
+    );
+  }
+
+  private getRawHeightOnly(x: number, z: number): number {
+    return clampWorldY(Math.round(7 + terrainNoise(x, z, this.seed)));
+  }
+
+  private getSupportedWaterLevel(
+    x: number,
+    z: number,
+    groundHeight: number
+  ): number | null {
+    if (groundHeight >= WATER_LEVEL) {
+      return null;
+    }
+
+    const neighborHeights = [
+      this.getRawHeightOnly(x + 1, z),
+      this.getRawHeightOnly(x - 1, z),
+      this.getRawHeightOnly(x, z + 1),
+      this.getRawHeightOnly(x, z - 1),
+    ];
+    const minNeighborHeight = Math.min(...neighborHeights);
+
+    if (minNeighborHeight < groundHeight - 1) {
+      return null;
+    }
+
+    return WATER_LEVEL;
   }
 
   private pickTransitionSurfaceBlock(
@@ -222,11 +343,11 @@ export class TerrainGenerator {
     }
 
     if (seedSurfaceBlockId === GRASS || seedSurfaceBlockId === DIRT) {
-      if (height <= WATER_LEVEL) {
-        return SAND;
+      if (materialBlend > 0.2) {
+        return GRASS;
       }
 
-      return materialBlend > 0.2 ? GRASS : rawColumn.surfaceBlockId;
+      return height <= WATER_LEVEL ? SAND : rawColumn.surfaceBlockId;
     }
 
     if (seedSurfaceBlockId === STONE) {

--- a/src/game/world/world-query.ts
+++ b/src/game/world/world-query.ts
@@ -1,0 +1,23 @@
+import type { AABB } from "../core/math/aabb";
+import type { CellCoord, CollisionKind, WorldBounds } from "../core/types";
+import type { BlockDefinition } from "./block-registry";
+import type { FluidAdjacency } from "./world";
+import type { LoadedWorldCell } from "./world-loader";
+
+export interface WorldQuery {
+  getBlockIdAtCell(x: number, y: number, z: number): number;
+  getBlockAtCell(x: number, y: number, z: number): BlockDefinition;
+  getCollisionKind(x: number, y: number, z: number): CollisionKind;
+  isCellSolid(x: number, y: number, z: number): boolean;
+  isCellFluid(x: number, y: number, z: number): boolean;
+  getFluidAdjacency(x: number, y: number, z: number): FluidAdjacency;
+  getHighestSolidCell(x: number, z: number): number | null;
+  getOverlappingCells(aabb: AABB): CellCoord[];
+  collidesAABB(aabb: AABB): boolean;
+}
+
+export interface RenderableWorldQuery extends WorldQuery {
+  getBounds(): WorldBounds;
+  getRenderableCells(): LoadedWorldCell[];
+  getExposedRenderableCells(): LoadedWorldCell[];
+}

--- a/src/game/world/world.test.ts
+++ b/src/game/world/world.test.ts
@@ -3,6 +3,7 @@ import { createBodyAABB } from "../core/math/aabb";
 import { vec3 } from "../core/math/vec3";
 import { PLAYER_COLLIDER } from "../rules/constants";
 import { VoxelWorld } from "./world";
+import type { LoadedWorldCell } from "./world-loader";
 
 describe("VoxelWorld", () => {
   it("treats water as fluid but not solid", () => {
@@ -30,6 +31,29 @@ describe("VoxelWorld", () => {
       south: false,
       east: true,
       west: false,
+    });
+  });
+
+  it("returns only exposed cells for preview rendering", () => {
+    const cells: LoadedWorldCell[] = [];
+
+    for (let x = 0; x < 3; x++) {
+      for (let y = 0; y < 3; y++) {
+        for (let z = 0; z < 3; z++) {
+          cells.push({ x, y, z, id: 1 });
+        }
+      }
+    }
+
+    const world = new VoxelWorld(cells);
+
+    expect(world.getRenderableCells()).toHaveLength(27);
+    expect(world.getExposedRenderableCells()).toHaveLength(26);
+    expect(world.getExposedRenderableCells()).not.toContainEqual({
+      x: 1,
+      y: 1,
+      z: 1,
+      id: 1,
     });
   });
 

--- a/src/game/world/world.ts
+++ b/src/game/world/world.ts
@@ -25,6 +25,7 @@ function cellKey(x: number, y: number, z: number): string {
 export class VoxelWorld {
   private readonly blockIds = new Map<string, number>();
   private readonly renderableCells: LoadedWorldCell[];
+  private readonly exposedRenderableCells: LoadedWorldCell[];
   private readonly bounds: WorldBounds;
 
   constructor(cells: LoadedWorldCell[]) {
@@ -41,6 +42,10 @@ export class VoxelWorld {
       maxZ = Math.max(maxZ, cell.z);
     }
 
+    this.exposedRenderableCells = cells.filter((cell) =>
+      this.hasExposedFace(cell.x, cell.y, cell.z)
+    );
+
     this.bounds = {
       min: { x: 0, y: 0, z: 0 },
       max: { x: maxX, y: maxY, z: maxZ },
@@ -53,6 +58,21 @@ export class VoxelWorld {
 
   public getRenderableCells(): LoadedWorldCell[] {
     return this.renderableCells;
+  }
+
+  public getExposedRenderableCells(): LoadedWorldCell[] {
+    return this.exposedRenderableCells;
+  }
+
+  private hasExposedFace(x: number, y: number, z: number): boolean {
+    return (
+      this.getBlockIdAtCell(x + 1, y, z) === 0 ||
+      this.getBlockIdAtCell(x - 1, y, z) === 0 ||
+      this.getBlockIdAtCell(x, y + 1, z) === 0 ||
+      this.getBlockIdAtCell(x, y - 1, z) === 0 ||
+      this.getBlockIdAtCell(x, y, z + 1) === 0 ||
+      this.getBlockIdAtCell(x, y, z - 1) === 0
+    );
   }
 
   public getBlockIdAtCell(x: number, y: number, z: number): number {

--- a/src/lib/texture.tsx
+++ b/src/lib/texture.tsx
@@ -51,12 +51,15 @@ export function useTextureMaterial(texture: MaterialTextureProps): Material {
       metalness: 0,
     };
 
-    if (texture.translucent) {
+    const opacity = texture.opacity ?? 1;
+
+    if (texture.translucent || opacity < 1) {
       materialProps.transparent = true;
-      materialProps.alphaTest = 0.2;
+      materialProps.alphaTest = opacity < 1 ? 0 : 0.2;
+      materialProps.depthWrite = opacity >= 0.95;
     }
 
-    if (texture.opacity) {
+    if (texture.opacity !== undefined) {
       materialProps.opacity = texture.opacity;
     }
 

--- a/src/server/getBooks.ts
+++ b/src/server/getBooks.ts
@@ -67,6 +67,20 @@ function normalizeSnapshotBooks(snapshotBooks: SnapshotBook[]): Book[] {
   }));
 }
 
+export function getFallbackBooks(): Book[] {
+  return normalizeSnapshotBooks(fallbackBooksData as SnapshotBook[]);
+}
+
+function formatError(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    return error.response
+      ? `status ${error.response.status}`
+      : (error.code ?? error.message);
+  }
+
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Convert manual book entries to full Book format with colors
  */
@@ -118,41 +132,45 @@ export default async function getBooks(): Promise<Book[]> {
   //   return booksCached;
   // }
 
-  // Fetch both currently reading and read books in parallel, plus process manual books
-  const [currentlyReadingBooks, readBooks, manualBooks] = await Promise.all([
-    fetchBooksFromShelf(currentlyReadingUrl),
-    fetchBooksFromShelf(readUrl),
-    processManualBooks(manualBooksData as ManualBook[]),
-  ]);
+  try {
+    // Fetch both currently reading and read books in parallel, plus process manual books
+    const [currentlyReadingBooks, readBooks, manualBooks] = await Promise.all([
+      fetchBooksFromShelf(currentlyReadingUrl),
+      fetchBooksFromShelf(readUrl),
+      processManualBooks(manualBooksData as ManualBook[]),
+    ]);
 
-  // Combine with currently reading books first
-  const allGoodreadsBooks = [...currentlyReadingBooks, ...readBooks];
+    // Combine with currently reading books first
+    const allGoodreadsBooks = [...currentlyReadingBooks, ...readBooks];
 
-  if (allGoodreadsBooks.length === 0) {
-    console.warn(
-      "Goodreads shelves returned no books; falling back to public/books.json."
-    );
-    return [
-      ...manualBooks,
-      ...normalizeSnapshotBooks(fallbackBooksData as SnapshotBook[]),
-    ];
-  }
-
-  // Get image colors for Goodreads books
-  const goodreadsBooksWithColors = await Promise.all(
-    allGoodreadsBooks.map(async (book) => {
-      const { fgColor, bgColor, hasValidImage } = await getImageColors(
-        book.imageUrl
+    if (allGoodreadsBooks.length === 0) {
+      console.warn(
+        "Goodreads shelves returned no books; falling back to public/books.json."
       );
-      return {
-        ...book,
-        fgColor,
-        bgColor,
-        hasValidImage,
-      };
-    })
-  );
+      return [...manualBooks, ...getFallbackBooks()];
+    }
 
-  // Manual books go first (most recently read), then Goodreads books
-  return [...manualBooks, ...goodreadsBooksWithColors];
+    // Get image colors for Goodreads books
+    const goodreadsBooksWithColors = await Promise.all(
+      allGoodreadsBooks.map(async (book) => {
+        const { fgColor, bgColor, hasValidImage } = await getImageColors(
+          book.imageUrl
+        );
+        return {
+          ...book,
+          fgColor,
+          bgColor,
+          hasValidImage,
+        };
+      })
+    );
+
+    // Manual books go first (most recently read), then Goodreads books
+    return [...manualBooks, ...goodreadsBooksWithColors];
+  } catch (error) {
+    console.error(
+      `Failed to build Goodreads bookshelf (${formatError(error)}); falling back to public/books.json.`
+    );
+    return getFallbackBooks();
+  }
 }

--- a/src/server/getPapers.ts
+++ b/src/server/getPapers.ts
@@ -32,20 +32,37 @@ export default async function getPapers(): Promise<ResearchPaper[]> {
     return [];
   }
 
-  const { data } = await axios.get(url, {
-    headers: {
-      Authorization: `Bearer ${env.ZOTERO_API_KEY}`,
-    },
-  });
+  try {
+    const { data } = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${env.ZOTERO_API_KEY}`,
+      },
+    });
 
-  const papers: ResearchPaper[] = data.map((paper: RawPaper) => ({
-    title: paper.data.title,
-    authorSummary: paper.meta.creatorSummary ?? "",
-    url: paper.data.url,
-    year: dateStringToYear(paper.meta.parsedDate),
-  }));
+    const papers: ResearchPaper[] = data.map((paper: RawPaper) => ({
+      title: paper.data.title,
+      authorSummary: paper.meta.creatorSummary ?? "",
+      url: paper.data.url,
+      year: dateStringToYear(paper.meta.parsedDate),
+    }));
 
-  return papers;
+    return papers;
+  } catch (error) {
+    console.error(
+      `Failed to fetch Zotero papers (${formatRequestError(error)}); falling back to an empty papers list.`
+    );
+    return [];
+  }
+}
+
+function formatRequestError(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    return error.response
+      ? `status ${error.response.status}`
+      : (error.code ?? error.message);
+  }
+
+  return error instanceof Error ? error.message : String(error);
 }
 
 function dateStringToYear(dateString: string): string {

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -15,6 +15,9 @@ body {
 }
 
 body {
+  --font-open-sans: "Open Sans", Arial, Helvetica, sans-serif;
+  --font-noto-sans-mono: "Noto Sans Mono", "SFMono-Regular", Consolas, monospace;
+  --font-roboto-slab: "Roboto Slab", Georgia, serif;
   color: $text-primary;
   background-color: $background-color;
   overflow-x: hidden;


### PR DESCRIPTION
### Motivation

- Preserve the authored 10x10 starter seed as the canonical preview anchor while enabling procedural continuation, clearer LOD/fidelity transitions, and camera-relative presentation.
- Unmix responsibilities that had accrued in `Map`/`ProceduralVoxelWorld`/fringe renderer by introducing explicit runtime, snapshot, starter-region, and terrain modules.
- Improve terrain quality and visual transitions (mid-detail, wireframes, particles) so generated terrain blends into the authored seed and avoids abrupt pop-in.

### Description

- Added design docs and an implementation roadmap in `design-docs/1-9-*.md` describing the refactor, terrain pipeline, LOD snapshot model, fringe, camera, and transition plans.
- Introduced a world runtime and procedural stack: `src/components/world/use-world-runtime.ts`, `src/game/world/procedural/procedural-runtime.ts`, `render-snapshot.ts`, `starter-region.ts`, `render-origin.ts`, `lod-policy.ts`, `procedural-world.ts`, `terrain-generator.ts`, `chunk-store.ts`, `chunk.ts`, `chunk-coords.ts`, and related types in `world-query.ts` and `chunk` modules implementing chunk caching, deterministic terrain generation, and seed-transition blending.
- Render and presentation changes: added `ProceduralMidDetailRenderer`, extended `WorldRenderer` to accept `cells` and per-cell `opacity`, added block opacity support in `Block` and propagated translucent/material changes, added per-vertex `fidelity`/`lodOpacity` attributes to fringe geometry and shader (`fringe-line-geometry.ts`, `fringe-line-field.ts`), and a procedural fringe path via `procedural-fringe-layout.ts` and `procedural-fringe-layout.test.ts`.
- UI/UX and integration: new `use-world-runtime` hook used by `Map` to select static vs procedural world, new `PlayerCameraFollow` helper for interactive mode, mobile WASD controls in `pages/world.tsx`, and `World`/`Map` updated to render mid-detail/high-detail/wireframe bands using a `ProceduralRenderSnapshot`.
- Server resilience and error handling: `getBooks` now falls back to `getFallbackBooks()` when Goodreads fails and added `getFallbackBooks()`; `getPapers` now catches fetch errors and logs a formatted message.
- Tests and compatibility: many tests added/updated to validate seeded region invariants, terrain generator determinism and blending, chunk store eviction, procedural LOD sampling, procedural runtime snapshots, fringe geometry attributes, and VoxelWorld exposed cell behavior (e.g. `src/game/world/procedural/procedural-world.test.ts`, `procedural-fringe-layout.test.ts`, `fringe-line-geometry.test.ts`, `world.test.ts`).

### Testing

- Ran unit tests with `bun test` covering procedural runtime and generator behavior: `procedural-world.test.ts`, `procedural-fringe-layout.test.ts`, `fringe-line-geometry.test.ts`, and updated `world.test.ts`; all test suites passed.
- Ran verification commands `bun run lint` and `bun run build` to ensure formatting and build integrity; lint and build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a246a7fcd20832399040a24c955bab5)